### PR TITLE
Handle telegram links with format `t.me/{channel}/{id}`

### DIFF
--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -59,7 +59,7 @@ export const KNOWN_LINK_PATTERNS = [
   },
   {
     key: KNOWN_LINKS.TELEGRAM,
-    patterns: ["^(https?:/{2})?(www.)?t.me/s/\\w*/\\d*"],
+    patterns: ["^(https?:/{2})?(www.)?t.me/(s/)?\\w*/\\d*"],
   },
   {
     key: KNOWN_LINKS.YOUTUBE,

--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -373,6 +373,11 @@ function* handleAssistantScrapeCall(action) {
     return;
   }
 
+  // if urlType is TELEGRAM, check formatting
+  if (urlType === KNOWN_LINKS.TELEGRAM) {
+    inputUrl = formatTelegramLink(inputUrl);
+  }
+
   try {
     let scrapeResult = null;
     if (decideWhetherToScrape(urlType, contentType, inputUrl)) {
@@ -443,6 +448,27 @@ function* extractFromLocalStorage(instagram_result, inputUrl, urlType) {
   yield put(setInputUrl(inputUrl, urlType));
   yield put(setScrapedData(text_result, null, [], image_result, video_result));
   yield put(setAssistantLoading(false));
+}
+
+/**
+ * Replaces "t.me/" with "t.me/s/" in telegram links if required.
+ * @param {String} url
+ * @return {String} url
+ */
+function formatTelegramLink(url) {
+  let urlType = matchPattern(url, KNOWN_LINK_PATTERNS);
+  if (urlType !== KNOWN_LINKS.TELEGRAM) {
+    throw new Error(
+      "formatTelegramLink: Expected telegram link but got " + urlType
+    );
+  }
+
+  // this pattern only matches telegram links of the format t.me/{channel}/{id} and NOT t.me/s/{channel}/{id}
+  const nonSPattern = "^(?:https:/{2})?(?:www.)?t.me/(?!s/)\\w*/\\d*";
+
+  return url.match(nonSPattern) !== null
+    ? url.replace("t.me/", "t.me/s/")
+    : url;
 }
 
 /**


### PR DESCRIPTION
:wave: Hi this is my first PR for the plugin. Just a simple one to begin with.

This just allows us to take one of the formats of telegram links: `t.me/{channel}/{id}` and replace it with `t.me/s/{channel}/{id}` to allow the scraper to work on the different page format the link returns.

Couple of etiquette questions:
* This branch is branched from `webpack-dev-rc-mv3` at present - what's the usual working branch for development?
* Similarly, which branch should this be merged into? It's compared against `pre-master` for now but can be changed.

I also noticed during working on this that links that don't include `https://` are not scraped successfully, I can work on this at a different time since it occurs in the backend.