### PR TITLE
Allow x.com versions of twitter links in assistant

### DIFF
--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -41,7 +41,7 @@ export const TYPE_PATTERNS = [
 export const KNOWN_LINK_PATTERNS = [
   {
     key: KNOWN_LINKS.TWITTER,
-    patterns: ["((https?:/{2})?(www.)?twitter.com/\\w{1,15}/status/\\d*)"],
+    patterns: ["((https?:/{2})?(www.)?(twitter|x).com/\\w{1,15}/status/\\d*)"],
   },
   {
     key: KNOWN_LINKS.TIKTOK,


### PR DESCRIPTION
We're [adding assistant backend support](https://github.com/GateNLP/we-verify-app-assistant/issues/67) for x.com versions of twitter.com links (ie tweaking the url pattern), so urls of that format should be treated as twitter links on the frontend as well.

@Sallaa Usual request to check/alter the base and target branches for the PR. Thanks! :rocket: 