### PR TITLE
Amend instagram url regex to accept path with username

### DIFF
--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -50,7 +50,9 @@ export const KNOWN_LINK_PATTERNS = [
   },
   {
     key: KNOWN_LINKS.INSTAGRAM,
-    patterns: ["((https?:\\/{2})?(www.)?instagram.com\\/p\\/.*)"],
+    patterns: [
+      "((https?:\\/{2})?(www.)?instagram.com\\/([A-Za-z0-9\\.]+\\/)?p\\/.*)",
+    ],
   },
   {
     key: KNOWN_LINKS.FACEBOOK,


### PR DESCRIPTION
Instagram links with username in its path are misclassified as a general site and leads to the scrape failing (e.g. https://www.instagram.com/donaldjtrumpjr/p/C07fqT_yQ30/?img_index=1)

It should be fixed with the regex change included in this PR.
