### PR TITLE
Fixed rendering issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weverify-plugin",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Fake news debunker by InVID & WeVerify",
-  "version": "0.78.0",
+  "version": "0.78.1",
   "description": "InVID WeVerify extension",
   "short_name": "Verification Plugin",
   "action": {
@@ -11,12 +11,16 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["contextMenus", "activeTab"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": [
+    "contextMenus",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "icons": {
     "16": "img/icon-16.png",
     "48": "img/icon-48.png",
     "128": "img/icon-128.png"
-    }
-  
+  }
 }

--- a/src/components/NavItems/tools/Forensic/components/imageCanvas/useImageCanvas.jsx
+++ b/src/components/NavItems/tools/Forensic/components/imageCanvas/useImageCanvas.jsx
@@ -32,7 +32,6 @@ const useImageCanvas = (
 
       const context = canvas.getContext("2d", {
         willReadFrequently: true,
-        desynchronized: true,
       });
 
       const image = await preloadImage(imgSrc);


### PR DESCRIPTION
On some computers, there is a rendering issue for the canvas element with the `desynchronized` option. This removes this option to prevent having white canvases.