### PR TITLE
changed icon to details list

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
@@ -10,7 +10,7 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import Link from "@mui/material/Link";
-import LaunchIcon from "@mui/icons-material/Launch";
+import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 import Typography from "@mui/material/Typography";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import Accordion from "@mui/material/Accordion";
@@ -98,7 +98,10 @@ const ExtractedSourceCredibilityDBKFDialog = ({
 
   return (
     <div>
-      <LaunchIcon style={{ cursor: "pointer" }} onClick={handleClickOpen} />
+      <ListAltOutlinedIcon
+        style={{ cursor: "pointer" }}
+        onClick={handleClickOpen}
+      />
       <Dialog
         onClose={handleClose}
         maxWidth={"lg"}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
@@ -10,7 +10,7 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import Link from "@mui/material/Link";
-import LaunchIcon from "@mui/icons-material/Launch";
+import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 import Typography from "@mui/material/Typography";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
@@ -33,7 +33,10 @@ const SourceCredibilityDBKFDialog = (props) => {
 
   return (
     <div>
-      <LaunchIcon onClick={handleClickOpen} />
+      <ListAltOutlinedIcon
+        style={{ cursor: "pointer" }}
+        onClick={handleClickOpen}
+      />
       <Dialog onClose={handleClose} maxWidth={"lg"} open={open}>
         <DialogTitle>
           <Typography>


### PR DESCRIPTION
In the URL Domain Analysis and the Extracted URLs, changed the outlink icon to a more appropriate list/details icon.
![image (25)](https://github.com/AFP-Medialab/verification-plugin/assets/44234896/200ec797-ea18-4c05-8548-ff7191ef02bd)
![image (26)](https://github.com/AFP-Medialab/verification-plugin/assets/44234896/9f8b103f-8018-4379-afac-b0871eea130b)
