### PR TITLE
Separate effect dependencies to avoid infinite loop (#586)

### DIFF
--- a/src/components/NavItems/tools/Gif/Components/TextImageCanvas.jsx
+++ b/src/components/NavItems/tools/Gif/Components/TextImageCanvas.jsx
@@ -42,14 +42,12 @@ const TextImageCanvas = ({
 
   // loads image
   useEffect(() => {
-    async function loadAndPreloadImage() {
-      const loadedImg = await preloadImage(imgSrc);
-      setImg(loadedImg);
-    }
+    preloadImage(imgSrc).then(setImg);
+  }, [imgSrc]);
 
-    loadAndPreloadImage();
+  useEffect(() => {
     if (img) handleExport();
-  }, [imgSrc, img]);
+  }, [img]);
 
   if (img) {
     //calculates width and height used for the canvas, to have the same proportions as the image


### PR DESCRIPTION
Split the preloadImage and handleExport into separate effects to avoid an infinite loop of the effect re-triggering every time the image fetch completes.

Fixes #586