### PR TITLE
Assistant/skeleton loading

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityResult.jsx
@@ -6,7 +6,6 @@ import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
-import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
 import ExtractedSourceCredibilityDBKFDialog from "./ExtractedSourceCredibilityDBKFDialog";
 import Typography from "@mui/material/Typography";
@@ -14,8 +13,6 @@ import Typography from "@mui/material/Typography";
 const ExtractedSourceCredibilityResult = ({
   extractedSourceCredibilityResults,
   sourceType,
-  Icon,
-  iconColor,
   urlColor,
   url,
 }) => {
@@ -33,10 +30,6 @@ const ExtractedSourceCredibilityResult = ({
     <List component={Stack} direction="row" disablePadding={true}>
       {sourceCredibilityResults ? (
         <ListItem>
-          <ListItemAvatar>
-            <Icon fontSize={"large"} color={iconColor} />
-          </ListItemAvatar>
-
           <ListItemText
             primary={
               <div>

--- a/src/components/NavItems/Assistant/AssistantFileSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantFileSelected.jsx
@@ -16,7 +16,6 @@ import {
   KNOWN_LINKS,
   selectCorrectActions,
 } from "./AssistantRuleBook";
-import Divider from "@mui/material/Divider";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 import { useNavigate } from "react-router-dom";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
 import Card from "@mui/material/Card";
-import { CardHeader, CircularProgress, Grid2, styled } from "@mui/material";
+import { CardHeader, Grid2, styled, Skeleton } from "@mui/material";
 import CardContent from "@mui/material/CardContent";
 import Accordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
@@ -277,7 +277,7 @@ const AssistantCredSignals = () => {
                 </Typography>
               </Grid2>
               <Grid2 size={{ xs: 8 }} align="start">
-                {newsFramingLoading && <CircularProgress color={"secondary"} />}
+                {newsFramingLoading && <Skeleton variant="rounded" width={400} height={40} />}
                 {newsFramingFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
                     {keyword("failed_to_load")}
@@ -345,7 +345,7 @@ const AssistantCredSignals = () => {
                 </Typography>
               </Grid2>
               <Grid2 size={{ xs: 8 }} align="start">
-                {newsGenreLoading && <CircularProgress color={"secondary"} />}
+                {newsGenreLoading && <Skeleton variant="rounded" width={400} height={40} />}
                 {newsGenreFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
                     {keyword("failed_to_load")}
@@ -424,7 +424,7 @@ const AssistantCredSignals = () => {
                 </Typography>
               </Grid2>
               <Grid2 size={{ xs: 8 }} align="start">
-                {persuasionLoading && <CircularProgress color={"secondary"} />}
+                {persuasionLoading && <Skeleton variant="rounded" width={400} height={40} />}
                 {persuasionFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
                     {keyword("failed_to_load")}
@@ -508,7 +508,7 @@ const AssistantCredSignals = () => {
               </Grid2>
               <Grid2 size={{ xs: 8 }} align="start">
                 {subjectivityLoading && (
-                  <CircularProgress color={"secondary"} />
+                  <Skeleton variant="rounded" width={400} height={40} />
                 )}
                 {subjectivityFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
@@ -605,7 +605,7 @@ const AssistantCredSignals = () => {
 
               <Grid2 size={{ xs: 8 }} align="start">
                 {role.includes("BETA_TESTER") && prevFactChecksLoading && (
-                  <CircularProgress color={"secondary"} />
+                  <Skeleton variant="rounded" width={400} height={40} />
                 )}
                 {role.includes("BETA_TESTER") && prevFactChecksFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
@@ -735,7 +735,7 @@ const AssistantCredSignals = () => {
               <Grid2 size={{ xs: 8 }} align="start">
                 {role.includes("BETA_TESTER") &&
                   machineGeneratedTextLoading && (
-                    <CircularProgress color={"secondary"} />
+                    <Skeleton variant="rounded" width={400} height={40} />
                   )}
                 {role.includes("BETA_TESTER") && machineGeneratedTextFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
@@ -277,7 +277,9 @@ const AssistantCredSignals = () => {
                 </Typography>
               </Grid2>
               <Grid2 size={{ xs: 8 }} align="start">
-                {newsFramingLoading && <Skeleton variant="rounded" width={400} height={40} />}
+                {newsFramingLoading && (
+                  <Skeleton variant="rounded" width="50%" height={40} />
+                )}
                 {newsFramingFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
                     {keyword("failed_to_load")}
@@ -345,7 +347,9 @@ const AssistantCredSignals = () => {
                 </Typography>
               </Grid2>
               <Grid2 size={{ xs: 8 }} align="start">
-                {newsGenreLoading && <Skeleton variant="rounded" width={400} height={40} />}
+                {newsGenreLoading && (
+                  <Skeleton variant="rounded" width="50%" height={40} />
+                )}
                 {newsGenreFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
                     {keyword("failed_to_load")}
@@ -424,7 +428,9 @@ const AssistantCredSignals = () => {
                 </Typography>
               </Grid2>
               <Grid2 size={{ xs: 8 }} align="start">
-                {persuasionLoading && <Skeleton variant="rounded" width={400} height={40} />}
+                {persuasionLoading && (
+                  <Skeleton variant="rounded" width="50%" height={40} />
+                )}
                 {persuasionFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
                     {keyword("failed_to_load")}
@@ -508,7 +514,7 @@ const AssistantCredSignals = () => {
               </Grid2>
               <Grid2 size={{ xs: 8 }} align="start">
                 {subjectivityLoading && (
-                  <Skeleton variant="rounded" width={400} height={40} />
+                  <Skeleton variant="rounded" width="50%" height={40} />
                 )}
                 {subjectivityFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
@@ -605,7 +611,7 @@ const AssistantCredSignals = () => {
 
               <Grid2 size={{ xs: 8 }} align="start">
                 {role.includes("BETA_TESTER") && prevFactChecksLoading && (
-                  <Skeleton variant="rounded" width={400} height={40} />
+                  <Skeleton variant="rounded" width="50%" height={40} />
                 )}
                 {role.includes("BETA_TESTER") && prevFactChecksFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>
@@ -735,7 +741,7 @@ const AssistantCredSignals = () => {
               <Grid2 size={{ xs: 8 }} align="start">
                 {role.includes("BETA_TESTER") &&
                   machineGeneratedTextLoading && (
-                    <Skeleton variant="rounded" width={400} height={40} />
+                    <Skeleton variant="rounded" width="50%" height={40} />
                   )}
                 {role.includes("BETA_TESTER") && machineGeneratedTextFail && (
                   <Typography sx={{ color: "text.secondary", align: "start" }}>

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -28,7 +28,9 @@ const ExtractedUrl = (
   let Icon;
   let iconColor;
 
-  {/* select correct icon and link colour */}
+  {
+    /* select correct icon and link colour */
+  }
   if (extractedSourceCred) {
     if (extractedSourceCred[link].caution) {
       sourceType = keyword("warning");
@@ -37,7 +39,7 @@ const ExtractedUrl = (
     } else if (extractedSourceCred[link].mixed) {
       sourceType = keyword("mentions");
       Icon = SentimentSatisfied;
-      iconColor = "warning";
+      iconColor = "action";
     } else if (extractedSourceCred[link].positive) {
       sourceType = keyword("fact_checker");
       Icon = TaskAltOutlined;
@@ -46,11 +48,10 @@ const ExtractedUrl = (
   }
 
   return (
-    <Grid2 container wrap="wrap" key={index} >
-
+    <Grid2 container wrap="wrap" key={index}>
       {/* icon */}
       <Grid2 size={{ xs: 1 }} align="center">
-        {loading && <Skeleton variant="circular" width={25} height={25} />}
+        {loading && <Skeleton variant="circular" width={20} height={20} />}
         {sourceType && done && <Icon color={iconColor} fontSize="large" />}
         {!sourceType && done && <LinkIcon />}
       </Grid2>
@@ -81,10 +82,7 @@ const ExtractedUrl = (
 
       {/* source cred details */}
       {sourceType && done ? (
-        <Grid2
-          size={{ xs: 1 }}
-          align="center"
-        >
+        <Grid2 size={{ xs: 1 }} align="center">
           <ExtractedSourceCredibilityResult
             extractedSourceCredibilityResults={extractedSourceCred[link]}
             sourceType={sourceType}
@@ -93,10 +91,7 @@ const ExtractedUrl = (
           />
         </Grid2>
       ) : loading ? (
-        <Grid2 
-          size={{ xs: 1 }} 
-          align="center"
-        >
+        <Grid2 size={{ xs: 1 }} align="center">
           <Skeleton variant="rounded" width={20} height={20} />
         </Grid2>
       ) : null}

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -2,12 +2,11 @@ import React from "react";
 import { useSelector } from "react-redux";
 
 import Card from "@mui/material/Card";
-import { CardHeader, CircularProgress, Grid2 } from "@mui/material";
+import { CardHeader, Grid2, Skeleton } from "@mui/material";
 import CardContent from "@mui/material/CardContent";
 import Link from "@mui/material/Link";
 import LinkIcon from "@mui/icons-material/Link";
 import Typography from "@mui/material/Typography";
-import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
 import SentimentSatisfied from "@mui/icons-material/SentimentSatisfied";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
@@ -15,6 +14,7 @@ import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import ExtractedSourceCredibilityResult from "../AssistantCheckResults/ExtractedSourceCredibilityResult";
 import Tooltip from "@mui/material/Tooltip";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import { TaskAltOutlined } from "@mui/icons-material";
 
 const ExtractedUrl = (
   index,
@@ -28,6 +28,7 @@ const ExtractedUrl = (
   let Icon;
   let iconColor;
 
+  {/* select correct icon and link colour */}
   if (extractedSourceCred) {
     if (extractedSourceCred[link].caution) {
       sourceType = keyword("warning");
@@ -36,19 +37,25 @@ const ExtractedUrl = (
     } else if (extractedSourceCred[link].mixed) {
       sourceType = keyword("mentions");
       Icon = SentimentSatisfied;
-      iconColor = "action";
+      iconColor = "warning";
     } else if (extractedSourceCred[link].positive) {
       sourceType = keyword("fact_checker");
-      Icon = CheckCircleOutlineIcon;
+      Icon = TaskAltOutlined;
       iconColor = "primary";
     }
   }
+
   return (
-    <Grid2 container wrap="wrap" key={index}>
+    <Grid2 container wrap="wrap" key={index} >
+
+      {/* icon */}
       <Grid2 size={{ xs: 1 }} align="center">
-        <LinkIcon />
+        {loading && <Skeleton variant="circular" width={25} height={25} />}
+        {sourceType && done && <Icon color={iconColor} fontSize="large" />}
+        {!sourceType && done && <LinkIcon />}
       </Grid2>
 
+      {/* extracted links */}
       <Grid2 size={{ xs: 10 }} align="left">
         <Typography>
           <Link
@@ -72,23 +79,25 @@ const ExtractedUrl = (
         </Typography>
       </Grid2>
 
+      {/* source cred details */}
       {sourceType && done ? (
         <Grid2
           size={{ xs: 1 }}
-          style={{ display: "flex", alignItems: "center" }}
+          align="center"
         >
           <ExtractedSourceCredibilityResult
             extractedSourceCredibilityResults={extractedSourceCred[link]}
             sourceType={sourceType}
-            Icon={Icon}
-            iconColor={iconColor}
             url={extractedSourceCred[link].resolvedLink}
             urlColor={extractedSourceCred[link].urlColor}
           />
         </Grid2>
       ) : loading ? (
-        <Grid2 size={{ xs: 1 }} style={{ alignItems: "right" }}>
-          <CircularProgress color={"secondary"} />
+        <Grid2 
+          size={{ xs: 1 }} 
+          align="center"
+        >
+          <Skeleton variant="rounded" width={20} height={20} />
         </Grid2>
       ) : null}
     </Grid2>

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
-import { CardHeader, Grid2 } from "@mui/material";
+import { CardHeader, Grid2, Skeleton } from "@mui/material";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
@@ -20,8 +20,7 @@ import {
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import VideoGridList from "../../../Shared/VideoGridList/VideoGridList";
-import { WarningOutlined } from "@mui/icons-material";
-import LinearProgress from "@mui/material/LinearProgress";
+import { ErrorOutlineOutlined } from "@mui/icons-material";
 
 const AssistantMediaResult = () => {
   const classes = useMyStyles();
@@ -70,26 +69,36 @@ const AssistantMediaResult = () => {
     dispatch(setProcessUrl(url, cType));
   };
   return (
-    <Grid2 container spacing={2}>
-      <Grid2 size={{ xs: 12 }} hidden={!urlMode}>
-        <Card data-testid="url-media-results">
+    // <Grid2 container >
+    //   <Grid2 size={{ xs: 12 }} hidden={!urlMode}>
+        <Card 
+          data-testid="url-media-results"
+          hidden={!urlMode || (!imageList.length && !videoList.length)}
+        >
           <CardHeader
             className={classes.assistantCardHeader}
             title={keyword("media_title")}
             action={
               <div style={{ display: "flex" }}>
                 <div
-                  hidden={dbkfImageMatch === null && dbkfVideoMatch === null}
+                  //hidden={dbkfImageMatch === null && dbkfVideoMatch === null}
                 >
-                  <Tooltip title={keyword("image_warning")}>
-                    <WarningOutlined
-                      className={classes.toolTipWarning}
-                      onClick={() => {
-                        dispatch(setWarningExpanded(!warningExpanded));
-                        window.scroll(0, 0);
-                      }}
-                    />
-                  </Tooltip>
+                  {console.log("dbkfMediaMatchLoading=", dbkfMediaMatchLoading)}
+                  {dbkfMediaMatchLoading && (
+                    <Skeleton variant="circular" />
+                  )}
+                  {(dbkfImageMatch || dbkfVideoMatch) && (
+                    <Tooltip title={keyword("image_warning")}>
+                      <ErrorOutlineOutlined
+                        color={"error"}
+                        className={classes.toolTipWarning}
+                        onClick={() => {
+                          dispatch(setWarningExpanded(!warningExpanded));
+                          window.scroll(0, 0);
+                        }}
+                      />
+                    </Tooltip>
+                  )}
                 </div>
                 <div>
                   <Tooltip
@@ -110,11 +119,11 @@ const AssistantMediaResult = () => {
               </div>
             }
           />
-          {
-            /*!ocrLoading && */ dbkfMediaMatchLoading && (
+          {/* {
+            /*!ocrLoading && *\/ dbkfMediaMatchLoading && (
               <LinearProgress variant={"indeterminate"} color={"secondary"} />
             )
-          }
+          } */}
 
           {/* selected image with recommended tools */}
           <CardContent>
@@ -127,9 +136,6 @@ const AssistantMediaResult = () => {
                   <Grid2 size={6}>
                     <AssistantProcessUrlActions />
                   </Grid2>
-                  {/* <Grid2 size={12}>
-                    <Divider/>
-                  </Grid2> */}
                 </Grid2>
               ) : (
                 <Grid2 container spacing={2}>
@@ -139,9 +145,6 @@ const AssistantMediaResult = () => {
                   <Grid2 size={6}>
                     <AssistantProcessUrlActions />
                   </Grid2>
-                  {/* <Grid2 size={12}>
-                    <Divider/>
-                  </Grid2> */}
                 </Grid2>
               )
             ) : null}
@@ -185,8 +188,6 @@ const AssistantMediaResult = () => {
             </div>
           ) : null}
         </Card>
-      </Grid2>
-    </Grid2>
   );
 };
 export default AssistantMediaResult;

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
-import { CardHeader, Grid2, Skeleton } from "@mui/material";
+import { CardHeader, Grid2, LinearProgress, Skeleton } from "@mui/material";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
@@ -78,11 +78,7 @@ const AssistantMediaResult = () => {
         title={keyword("media_title")}
         action={
           <div style={{ display: "flex" }}>
-            <div
-            //hidden={dbkfImageMatch === null && dbkfVideoMatch === null}
-            >
-              {console.log("dbkfMediaMatchLoading=", dbkfMediaMatchLoading)}
-              {dbkfMediaMatchLoading && <Skeleton variant="circular" />}
+            <div>
               {(dbkfImageMatch || dbkfVideoMatch) && (
                 <Tooltip title={keyword("image_warning")}>
                   <WarningAmber
@@ -115,6 +111,12 @@ const AssistantMediaResult = () => {
           </div>
         }
       />
+
+      {dbkfMediaMatchLoading ? (
+        <div>
+          <LinearProgress />
+        </div>
+      ) : null}
 
       {/* selected image with recommended tools */}
       <CardContent>

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -20,7 +20,7 @@ import {
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import VideoGridList from "../../../Shared/VideoGridList/VideoGridList";
-import { ErrorOutlineOutlined } from "@mui/icons-material";
+import { WarningAmber } from "@mui/icons-material";
 
 const AssistantMediaResult = () => {
   const classes = useMyStyles();
@@ -69,125 +69,116 @@ const AssistantMediaResult = () => {
     dispatch(setProcessUrl(url, cType));
   };
   return (
-    // <Grid2 container >
-    //   <Grid2 size={{ xs: 12 }} hidden={!urlMode}>
-        <Card 
-          data-testid="url-media-results"
-          hidden={!urlMode || (!imageList.length && !videoList.length)}
-        >
-          <CardHeader
-            className={classes.assistantCardHeader}
-            title={keyword("media_title")}
-            action={
-              <div style={{ display: "flex" }}>
-                <div
-                  //hidden={dbkfImageMatch === null && dbkfVideoMatch === null}
-                >
-                  {console.log("dbkfMediaMatchLoading=", dbkfMediaMatchLoading)}
-                  {dbkfMediaMatchLoading && (
-                    <Skeleton variant="circular" />
-                  )}
-                  {(dbkfImageMatch || dbkfVideoMatch) && (
-                    <Tooltip title={keyword("image_warning")}>
-                      <ErrorOutlineOutlined
-                        color={"error"}
-                        className={classes.toolTipWarning}
-                        onClick={() => {
-                          dispatch(setWarningExpanded(!warningExpanded));
-                          window.scroll(0, 0);
-                        }}
-                      />
-                    </Tooltip>
-                  )}
-                </div>
-                <div>
-                  <Tooltip
-                    interactive={"true"}
-                    title={
-                      <div
-                        className={"content"}
-                        dangerouslySetInnerHTML={{
-                          __html: keyword("media_tooltip"),
-                        }}
-                      />
-                    }
-                    classes={{ tooltip: classes.assistantTooltip }}
-                  >
-                    <HelpOutlineOutlinedIcon className={classes.toolTipIcon} />
-                  </Tooltip>
-                </div>
-              </div>
-            }
-          />
-          {/* {
-            /*!ocrLoading && *\/ dbkfMediaMatchLoading && (
-              <LinearProgress variant={"indeterminate"} color={"secondary"} />
-            )
-          } */}
+    <Card
+      data-testid="url-media-results"
+      hidden={!urlMode || (!imageList.length && !videoList.length)}
+    >
+      <CardHeader
+        className={classes.assistantCardHeader}
+        title={keyword("media_title")}
+        action={
+          <div style={{ display: "flex" }}>
+            <div
+            //hidden={dbkfImageMatch === null && dbkfVideoMatch === null}
+            >
+              {console.log("dbkfMediaMatchLoading=", dbkfMediaMatchLoading)}
+              {dbkfMediaMatchLoading && <Skeleton variant="circular" />}
+              {(dbkfImageMatch || dbkfVideoMatch) && (
+                <Tooltip title={keyword("image_warning")}>
+                  <WarningAmber
+                    color={"warning"}
+                    className={classes.toolTipWarning}
+                    onClick={() => {
+                      dispatch(setWarningExpanded(!warningExpanded));
+                      window.scroll(0, 0);
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </div>
+            <div>
+              <Tooltip
+                interactive={"true"}
+                title={
+                  <div
+                    className={"content"}
+                    dangerouslySetInnerHTML={{
+                      __html: keyword("media_tooltip"),
+                    }}
+                  />
+                }
+                classes={{ tooltip: classes.assistantTooltip }}
+              >
+                <HelpOutlineOutlinedIcon className={classes.toolTipIcon} />
+              </Tooltip>
+            </div>
+          </div>
+        }
+      />
 
-          {/* selected image with recommended tools */}
+      {/* selected image with recommended tools */}
+      <CardContent>
+        {processUrl !== null ? (
+          resultIsImage ? (
+            <Grid2 container spacing={2}>
+              <Grid2 size={6}>
+                <AssistantImageResult />
+              </Grid2>
+              <Grid2 size={6}>
+                <AssistantProcessUrlActions />
+              </Grid2>
+            </Grid2>
+          ) : (
+            <Grid2 container spacing={2}>
+              <Grid2 size={6}>
+                <AssistantVideoResult />
+              </Grid2>
+              <Grid2 size={6}>
+                <AssistantProcessUrlActions />
+              </Grid2>
+            </Grid2>
+          )
+        ) : null}
+      </CardContent>
+
+      {/* image grid and video grid of extracted media */}
+      {!singleMediaPresent ? (
+        <div>
+          {/* select media */}
           <CardContent>
-            {processUrl !== null ? (
-              resultIsImage ? (
-                <Grid2 container spacing={2}>
-                  <Grid2 size={6}>
-                    <AssistantImageResult />
-                  </Grid2>
-                  <Grid2 size={6}>
-                    <AssistantProcessUrlActions />
-                  </Grid2>
-                </Grid2>
-              ) : (
-                <Grid2 container spacing={2}>
-                  <Grid2 size={6}>
-                    <AssistantVideoResult />
-                  </Grid2>
-                  <Grid2 size={6}>
-                    <AssistantProcessUrlActions />
-                  </Grid2>
-                </Grid2>
-              )
-            ) : null}
+            <Typography
+              component={"div"}
+              sx={{ textAlign: "start" }}
+              variant={"subtitle1"}
+            >
+              {keyword("media_below")}
+            </Typography>
           </CardContent>
 
-          {/* image grid and video grid of extracted media */}
-          {!singleMediaPresent ? (
-            <div>
-              {/* select media */}
-              <CardContent>
-                <Typography
-                  component={"div"}
-                  sx={{ textAlign: "start" }}
-                  variant={"subtitle1"}
-                >
-                  {keyword("media_below")}
-                </Typography>
-              </CardContent>
+          {/* image list */}
+          <CardContent>
+            <ImageGridList
+              list={imageList}
+              height={60}
+              cols={5}
+              handleClick={(event) => {
+                submitMediaToProcess(event);
+              }}
+            />
+          </CardContent>
 
-              {/* image list */}
-              <CardContent>
-                <ImageGridList
-                  list={imageList}
-                  height={60}
-                  cols={5}
-                  handleClick={(event) => {
-                    submitMediaToProcess(event);
-                  }}
-                />
-              </CardContent>
-
-              {/* video list */}
-              <CardContent>
-                <VideoGridList
-                  list={videoList}
-                  handleClick={(vidLink) => {
-                    submitMediaToProcess(vidLink);
-                  }}
-                />
-              </CardContent>
-            </div>
-          ) : null}
-        </Card>
+          {/* video list */}
+          <CardContent>
+            <VideoGridList
+              list={videoList}
+              handleClick={(vidLink) => {
+                submitMediaToProcess(vidLink);
+              }}
+            />
+          </CardContent>
+        </div>
+      ) : null}
+    </Card>
   );
 };
 export default AssistantMediaResult;

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
-import { CardHeader, Grid2, LinearProgress, Skeleton } from "@mui/material";
+import { CardHeader, Grid2, LinearProgress } from "@mui/material";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
@@ -7,7 +7,7 @@ import CardMedia from "@mui/material/CardMedia";
 import Collapse from "@mui/material/Collapse";
 import FindInPageIcon from "@mui/icons-material/FindInPage";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { Grid2, IconButton, Skeleton, Stack } from "@mui/material";
+import { Grid2, IconButton } from "@mui/material";
 import Typography from "@mui/material/Typography";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
@@ -39,128 +39,110 @@ const AssistantSCResults = () => {
   const mixedSourceCred = useSelector(
     (state) => state.assistant.mixedSourceCred,
   );
-  const inputSCLoading = useSelector(
-    (state) => state.assistant.inputSCLoading,
-  );
-
-  // currently not working
-  console.log("1 inputSCLoading=", inputSCLoading);
-  if (inputSCLoading) {
-    console.log("2 inputSCLoading=", inputSCLoading);
-    return (
-      <Card variant={"outlined"} sx={{ mt: 4 }}>
-        <Stack direction="column" spacing={4} p={4}>
-          <Skeleton variant="rounded" height={40} />
-        </Stack>
-      </Card>
-    );
-  }
 
   return (
-    // <Box>
-      <Card variant={"outlined"} className={classes.sourceCredibilityBorder}>
-        <Grid2 container>
-          <Grid2 size={{ xs: 12 }} className={classes.displayFlex}>
-            <CardMedia>
-              <Box m={1}>
-                <FindInPageIcon fontSize={"large"} color={"primary"} />
-              </Box>
-            </CardMedia>
-
-            <Box m={1} />
-
-            <Box mt={1.5}>
-              <Typography component={"span"} variant={"h6"}>
-                {keyword("url_domain_analysis")}
-              </Typography>
+    <Card variant={"outlined"} className={classes.sourceCredibilityBorder}>
+      <Grid2 container>
+        <Grid2 size={{ xs: 12 }} className={classes.displayFlex}>
+          <CardMedia>
+            <Box m={1}>
+              <FindInPageIcon fontSize={"large"} color={"primary"} />
             </Box>
+          </CardMedia>
 
-            <IconButton
-              className={classes.assistantIconRight}
-              onClick={() => dispatch(setAssuranceExpanded(!assuranceExpanded))}
-            >
-              <ExpandMoreIcon color={"primary"} />
-            </IconButton>
-          </Grid2>
+          <Box m={1} />
 
-          <Grid2 size={{ xs: 12 }}>
-            <Collapse
-              in={assuranceExpanded}
-              className={classes.assistantBackground}
-            >
-              <Box mt={3} ml={2}>
-                {positiveSourCred ? (
-                  <div>
-                    <Typography
-                      variant={"subtitle1"}
-                      className={classes.fontBold}
-                    >
-                      {keyword("fact_checker")}
-                    </Typography>
-                    <SourceCredibilityResult
-                      scResultFiltered={positiveSourCred}
-                      icon={CheckCircleOutlineIcon}
-                      iconColor="primary"
-                    />
-                  </div>
-                ) : null}
+          <Box mt={1.5}>
+            <Typography component={"span"} variant={"h6"}>
+              {keyword("url_domain_analysis")}
+            </Typography>
+          </Box>
 
-                {cautionSourceCred ? (
-                  <div>
-                    <Typography
-                      variant={"subtitle1"}
-                      className={classes.fontBold}
-                    >
-                      {keyword("warning_title")}
-                    </Typography>
-                    <SourceCredibilityResult
-                      scResultFiltered={cautionSourceCred}
-                      icon={ErrorOutlineOutlinedIcon}
-                      iconColor="error"
-                    />
-                  </div>
-                ) : null}
-
-                {mixedSourceCred ? (
-                  <div>
-                    <Typography
-                      variant={"subtitle1"}
-                      className={classes.fontBold}
-                    >
-                      {keyword("mentions")}
-                    </Typography>
-                    <SourceCredibilityResult
-                      scResultFiltered={mixedSourceCred}
-                      icon={SentimentSatisfied}
-                      iconColor="action"
-                    />
-                  </div>
-                ) : null}
-
-                <Box mr={2} mb={1}>
-                  <Tooltip
-                    interactive={"true"}
-                    leaveDelay={50}
-                    style={{ display: "flex", marginLeft: "auto" }}
-                    title={
-                      <div
-                        className={"content"}
-                        dangerouslySetInnerHTML={{
-                          __html: keyword("sc_tooltip"),
-                        }}
-                      />
-                    }
-                    classes={{ tooltip: classes.assistantTooltip }}
-                  >
-                    <HelpOutlineOutlinedIcon color={"action"} />
-                  </Tooltip>
-                </Box>
-              </Box>
-            </Collapse>
-          </Grid2>
+          <IconButton
+            className={classes.assistantIconRight}
+            onClick={() => dispatch(setAssuranceExpanded(!assuranceExpanded))}
+          >
+            <ExpandMoreIcon color={"primary"} />
+          </IconButton>
         </Grid2>
-      </Card>
 
+        <Grid2 size={{ xs: 12 }}>
+          <Collapse
+            in={assuranceExpanded}
+            className={classes.assistantBackground}
+          >
+            <Box mt={3} ml={2}>
+              {positiveSourCred ? (
+                <div>
+                  <Typography
+                    variant={"subtitle1"}
+                    className={classes.fontBold}
+                  >
+                    {keyword("fact_checker")}
+                  </Typography>
+                  <SourceCredibilityResult
+                    scResultFiltered={positiveSourCred}
+                    icon={CheckCircleOutlineIcon}
+                    iconColor="primary"
+                  />
+                </div>
+              ) : null}
+
+              {cautionSourceCred ? (
+                <div>
+                  <Typography
+                    variant={"subtitle1"}
+                    className={classes.fontBold}
+                  >
+                    {keyword("warning_title")}
+                  </Typography>
+                  <SourceCredibilityResult
+                    scResultFiltered={cautionSourceCred}
+                    icon={ErrorOutlineOutlinedIcon}
+                    iconColor="error"
+                  />
+                </div>
+              ) : null}
+
+              {mixedSourceCred ? (
+                <div>
+                  <Typography
+                    variant={"subtitle1"}
+                    className={classes.fontBold}
+                  >
+                    {keyword("mentions")}
+                  </Typography>
+                  <SourceCredibilityResult
+                    scResultFiltered={mixedSourceCred}
+                    icon={SentimentSatisfied}
+                    iconColor="action"
+                  />
+                </div>
+              ) : null}
+
+              <Box mr={2} mb={1}>
+                <Tooltip
+                  interactive={"true"}
+                  leaveDelay={50}
+                  style={{ display: "flex", marginLeft: "auto" }}
+                  title={
+                    <div
+                      className={"content"}
+                      dangerouslySetInnerHTML={{
+                        __html: keyword("sc_tooltip"),
+                      }}
+                    />
+                  }
+                  classes={{ tooltip: classes.assistantTooltip }}
+                >
+                  <HelpOutlineOutlinedIcon color={"action"} />
+                </Tooltip>
+              </Box>
+            </Box>
+          </Collapse>
+        </Grid2>
+      </Grid2>
+    </Card>
   );
 };
 export default AssistantSCResults;

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
@@ -7,7 +7,7 @@ import CardMedia from "@mui/material/CardMedia";
 import Collapse from "@mui/material/Collapse";
 import FindInPageIcon from "@mui/icons-material/FindInPage";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { Grid2, IconButton } from "@mui/material";
+import { Grid2, IconButton, Skeleton, Stack } from "@mui/material";
 import Typography from "@mui/material/Typography";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
@@ -39,9 +39,25 @@ const AssistantSCResults = () => {
   const mixedSourceCred = useSelector(
     (state) => state.assistant.mixedSourceCred,
   );
+  const inputSCLoading = useSelector(
+    (state) => state.assistant.inputSCLoading,
+  );
+
+  // currently not working
+  console.log("1 inputSCLoading=", inputSCLoading);
+  if (inputSCLoading) {
+    console.log("2 inputSCLoading=", inputSCLoading);
+    return (
+      <Card variant={"outlined"} sx={{ mt: 4 }}>
+        <Stack direction="column" spacing={4} p={4}>
+          <Skeleton variant="rounded" height={40} />
+        </Stack>
+      </Card>
+    );
+  }
 
   return (
-    <Box mb={2} pl={1}>
+    // <Box>
       <Card variant={"outlined"} className={classes.sourceCredibilityBorder}>
         <Grid2 container>
           <Grid2 size={{ xs: 12 }} className={classes.displayFlex}>
@@ -144,7 +160,7 @@ const AssistantSCResults = () => {
           </Grid2>
         </Grid2>
       </Card>
-    </Box>
+
   );
 };
 export default AssistantSCResults;

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
@@ -46,7 +46,7 @@ const AssistantWarnings = () => {
               className={classes.assistantIconRight}
               onClick={() => dispatch(setWarningExpanded(!warningExpanded))}
             >
-              <ExpandMoreIcon style={{ color: "red" }} />
+              <ExpandMoreIcon color={"error"} />
             </IconButton>
           </Grid2>
           <Grid2 size={{ xs: 12 }}>

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
@@ -5,7 +5,6 @@ import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
 import Collapse from "@mui/material/Collapse";
-import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Grid2, IconButton } from "@mui/material";
 import Typography from "@mui/material/Typography";
@@ -14,6 +13,7 @@ import { setWarningExpanded } from "../../../../redux/actions/tools/assistantAct
 import DbkfTextResults from "../AssistantCheckResults/DbkfTextResults";
 import DbkfMediaResults from "../AssistantCheckResults/DbkfMediaResults";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import { WarningAmber } from "@mui/icons-material";
 
 const AssistantWarnings = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");
@@ -25,44 +25,42 @@ const AssistantWarnings = () => {
   );
 
   return (
-    <Box mb={2} pl={1}>
-      <Card variant={"outlined"} className={classes.assistantWarningBorder}>
-        <Grid2 container>
-          <Grid2 size={{ xs: 12 }} style={{ display: "flex" }}>
-            <CardMedia>
-              <Box m={1}>
-                <ErrorOutlineOutlinedIcon color={"error"} fontSize={"large"} />
+    <Card variant={"outlined"} className={classes.assistantWarningBorder}>
+      <Grid2 container>
+        <Grid2 size={{ xs: 12 }} style={{ display: "flex" }}>
+          <CardMedia>
+            <Box m={1}>
+              <WarningAmber color={"warning"} fontSize={"large"} />
+            </Box>
+          </CardMedia>
+          <Box m={1} />
+          <div>
+            <Typography component={"span"} variant={"h6"} color={"warning"}>
+              <Box mt={1.5} fontWeight="fontWeightBold">
+                {keyword("warning_title")}
               </Box>
-            </CardMedia>
-            <Box m={1} />
-            <div>
-              <Typography component={"span"} variant={"h6"} color={"error"}>
-                <Box mt={1.5} fontWeight="fontWeightBold">
-                  {keyword("warning_title")}
-                </Box>
-              </Typography>
-            </div>
-            <IconButton
-              className={classes.assistantIconRight}
-              onClick={() => dispatch(setWarningExpanded(!warningExpanded))}
-            >
-              <ExpandMoreIcon color={"error"} />
-            </IconButton>
-          </Grid2>
-          <Grid2 size={{ xs: 12 }}>
-            <Collapse
-              in={warningExpanded}
-              className={classes.assistantBackground}
-            >
-              <Box m={1} />
-              <DbkfTextResults />
-
-              <DbkfMediaResults />
-            </Collapse>
-          </Grid2>
+            </Typography>
+          </div>
+          <IconButton
+            className={classes.assistantIconRight}
+            onClick={() => dispatch(setWarningExpanded(!warningExpanded))}
+          >
+            <ExpandMoreIcon color={"warning"} />
+          </IconButton>
         </Grid2>
-      </Card>
-    </Box>
+        <Grid2 size={{ xs: 12 }}>
+          <Collapse
+            in={warningExpanded}
+            className={classes.assistantBackground}
+          >
+            <Box m={1} />
+            <DbkfTextResults />
+
+            <DbkfMediaResults />
+          </Collapse>
+        </Grid2>
+      </Grid2>
+    </Card>
   );
 };
 export default AssistantWarnings;

--- a/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
@@ -43,6 +43,7 @@ const AssistantUrlSelected = (props) => {
   );
 
   const handleSubmissionURL = () => {
+    cleanAssistant();
     setUrl(formInput);
     dispatch(submitInputUrl(formInput));
     //trackEvent("submission", "assistant", "page assistant", formInput);

--- a/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
@@ -2,11 +2,10 @@ import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
-import { Box, CardHeader, TextField } from "@mui/material/";
+import { Box, CardHeader, Skeleton, TextField } from "@mui/material/";
 import Button from "@mui/material//Button";
 import Card from "@mui/material//Card";
 import CardContent from "@mui/material//CardContent";
-import LinearProgress from "@mui/material//LinearProgress";
 import Typography from "@mui/material//Typography";
 import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
@@ -73,6 +72,8 @@ const AssistantUrlSelected = (props) => {
   };
 
   return (
+    <div>
+
     <Card>
       <CardHeader
         className={classes.assistantCardHeader}
@@ -82,9 +83,6 @@ const AssistantUrlSelected = (props) => {
           </Typography>
         }
       />
-
-      {/* loading */}
-      {loading && <LinearProgress color={"secondary"} />}
 
       <CardContent>
         <Box sx={{ mr: 2 }}>
@@ -143,6 +141,17 @@ const AssistantUrlSelected = (props) => {
         </Box>
       </CardContent>
     </Card>
+
+    {loading && (
+      <Card sx={{ mt: 4 }}>
+        <Stack direction="column" spacing={4} p={4}>
+          <Skeleton variant="rounded" height={40} />
+          <Skeleton variant="rounded" width={400} height={40} />
+        </Stack>
+      </Card>
+    )}
+
+    </div>
   );
 };
 

--- a/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
@@ -73,84 +73,82 @@ const AssistantUrlSelected = (props) => {
 
   return (
     <div>
+      <Card>
+        <CardHeader
+          className={classes.assistantCardHeader}
+          title={
+            <Typography style={{ fontWeight: "bold", fontSize: 20 }}>
+              {keyword("assistant_give_url")}
+            </Typography>
+          }
+        />
 
-    <Card>
-      <CardHeader
-        className={classes.assistantCardHeader}
-        title={
-          <Typography style={{ fontWeight: "bold", fontSize: 20 }}>
-            {keyword("assistant_give_url")}
-          </Typography>
-        }
-      />
-
-      <CardContent>
-        <Box sx={{ mr: 2 }}>
-          <form>
-            <Stack>
-              <Stack
-                direction="row"
-                spacing={2}
-                justifyContent="flex-start"
-                alignItems="center"
-              >
-                {/* text box */}
-                <TextField
-                  variant="outlined"
-                  label={keyword("assistant_paste_url")}
-                  style={{ margin: 8 }}
-                  placeholder={""}
-                  fullWidth
-                  value={formInput || ""}
-                  onChange={(e) => setFormInput(e.target.value)}
-                  data-testid="assistant-url-selected-input"
-                />
-
-                {/* submit button */}
-                <Button
-                  type="submit"
-                  variant="contained"
-                  color="primary"
-                  data-testid="assistant-url-selected-analyse-btn"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleSubmissionURL();
-                  }}
-                >
-                  {keyword("button_submit")}
-                </Button>
-              </Stack>
-
-              {/* archive */}
-              {inputUrl === null ? null : (
+        <CardContent>
+          <Box sx={{ mr: 2 }}>
+            <form>
+              <Stack>
                 <Stack
                   direction="row"
+                  spacing={2}
                   justifyContent="flex-start"
-                  alignItems="left"
+                  alignItems="center"
                 >
+                  {/* text box */}
+                  <TextField
+                    variant="outlined"
+                    label={keyword("assistant_paste_url")}
+                    style={{ margin: 8 }}
+                    placeholder={""}
+                    fullWidth
+                    value={formInput || ""}
+                    onChange={(e) => setFormInput(e.target.value)}
+                    data-testid="assistant-url-selected-input"
+                  />
+
+                  {/* submit button */}
                   <Button
-                    onClick={() => handleArchive()}
-                    startIcon={<ArchiveOutlinedIcon />}
+                    type="submit"
+                    variant="contained"
+                    color="primary"
+                    data-testid="assistant-url-selected-analyse-btn"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      handleSubmissionURL();
+                    }}
                   >
-                    <label>{keyword("archive_link")}</label>
+                    {keyword("button_submit")}
                   </Button>
                 </Stack>
-              )}
-            </Stack>
-          </form>
-        </Box>
-      </CardContent>
-    </Card>
 
-    {loading && (
-      <Card sx={{ mt: 4 }}>
-        <Stack direction="column" spacing={4} p={4}>
-          <Skeleton variant="rounded" height={40} />
-          <Skeleton variant="rounded" width={400} height={40} />
-        </Stack>
+                {/* archive */}
+                {inputUrl === null ? null : (
+                  <Stack
+                    direction="row"
+                    justifyContent="flex-start"
+                    alignItems="left"
+                  >
+                    <Button
+                      onClick={() => handleArchive()}
+                      startIcon={<ArchiveOutlinedIcon />}
+                    >
+                      <label>{keyword("archive_link")}</label>
+                    </Button>
+                  </Stack>
+                )}
+              </Stack>
+            </form>
+          </Box>
+        </CardContent>
       </Card>
-    )}
 
+      {loading && (
+        <Card sx={{ mt: 4 }}>
+          <Stack direction="column" spacing={4} p={4}>
+            <Skeleton variant="rounded" height={40} />
+            <Skeleton variant="rounded" width="50%" height={40} />
+          </Stack>
+        </Card>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Skeleton loading
- skeleton box appears when clicking Submit
- Media Card, for loading DBKF changed linear progress to green for now (needs more thought where to place skeleton loading)
- Extracted URLs have skeleton circles an rectangles for loading URL Domain Analysis
- Credibility Signals have skeleton text box 

(Removed move extra Box or Grid2 hence the big changes in a couple of files)