### PR TITLE
Jmafoster1/173 back to original query

### DIFF
--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -121,8 +121,7 @@ const Assistant = () => {
       dispatch(setUrlMode(true));
       setFormInput(uri);
       dispatch(submitInputUrl(uri));
-      navigate("/app/assistant/");
-      //history.push("/app/assistant/");
+      navigate("/app/assistant/" + encodeURIComponent(url));
     }
   }, [url]);
 

--- a/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
@@ -48,7 +48,7 @@ const AssistantUrlSelected = (props) => {
   const handleSubmissionURL = () => {
     setUrl(formInput);
     dispatch(submitInputUrl(formInput));
-    navigate(encodeURIComponent(formInput));
+    navigate("/app/assistant/" + encodeURIComponent(formInput));
     //trackEvent("submission", "assistant", "page assistant", formInput);
   };
 

--- a/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom"; // version 5.2.0
 
 import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
 import { Box, CardHeader, TextField } from "@mui/material/";
@@ -19,6 +20,7 @@ import Stack from "@mui/material/Stack";
 
 const AssistantUrlSelected = (props) => {
   // styles, language, dispatch, params
+  const navigate = useNavigate();
   const classes = useMyStyles();
   const dispatch = useDispatch();
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");
@@ -29,7 +31,7 @@ const AssistantUrlSelected = (props) => {
   const loading = useSelector((state) => state.assistant.loading);
 
   //local state
-  const formInput = props.formInput;
+  const formInput = props.formInput || "";
   const setFormInput = (value) => props.setFormInput(value);
   const cleanAssistant = () => props.cleanAssistant();
   const [url, setUrl] = useState(undefined);
@@ -46,6 +48,7 @@ const AssistantUrlSelected = (props) => {
   const handleSubmissionURL = () => {
     setUrl(formInput);
     dispatch(submitInputUrl(formInput));
+    navigate(encodeURIComponent(formInput));
     //trackEvent("submission", "assistant", "page assistant", formInput);
   };
 


### PR DESCRIPTION
This adds the queried URL to the assistant URL to make it easier to return to previous searches. The query stays in the search box and, since part of the URL, allows users to navigate using the "back" button on the browser if they navigate away from the page (e.g. to use one of the tools on a piece of media).

Relates to the first point of [this issue](https://github.com/GateNLP/we-verify-app-assistant/issues/173).