### PR TITLE
feat: drag-and-drop support for StringFileUploadField

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@reduxjs/toolkit": "^1.9.7",
         "@types/chrome": "^0.0.272",
         "@wavesurfer/react": "^1.0.7",
+        "attr-accept": "^2.2.5",
         "axios": "^1.7.7",
         "buffer": "^6.0.3",
         "c2pa": "^0.17.5",
@@ -5497,6 +5498,14 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/attr-accept": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/available-typed-arrays": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@reduxjs/toolkit": "^1.9.7",
     "@types/chrome": "^0.0.272",
     "@wavesurfer/react": "^1.0.7",
+    "attr-accept": "^2.2.5",
     "axios": "^1.7.7",
     "buffer": "^6.0.3",
     "c2pa": "^0.17.5",


### PR DESCRIPTION
Add support for loading a local file into a `StringFileUploadField` via drag and drop.  Dragging a file onto the button will change the mouse cursor to indicate whether or not the file is acceptable according to the `fileInputTypesAccepted` filter, and dropping an acceptable file behaves the same as clicking the button and selecting that same file from the usual file chooser.

N.B. added dependency on https://www.npmjs.com/package/attr-accept to test dragged files against the same "accept" value as the regular file input.

Closes #576