### PR TITLE
Change telegram mapping

### DIFF
--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -684,14 +684,14 @@ function formatTelegramLink(url) {
     );
   }
 
-  // this pattern only matches telegram links of the format t.me/{channel}/{id} and NOT t.me/s/{channel}/{id}
-  const nonSPattern = "^(?:https:/{2})?(?:www.)?t.me/(?!s/)\\w*/\\d*";
+  // Check if the embed parameter already exists
+  const hasEmbed = url.includes("?embed=");
 
-  return url.match(nonSPattern) !== null
-    ? url.replace("t.me/", "t.me/s/")
-    : url;
+  const newUrl = url.replace("t.me/s/", "t.me/");
+
+  // Add ?embed=1 if not already present
+  return hasEmbed ? newUrl : `${newUrl}?embed=1`;
 }
-
 /**
  * PREPROCESS FUNCTIONS
  **/


### PR DESCRIPTION
Changing the mapping of `https://t.me/channel/num` to `https://t.me/channel/num?embed=1` instead of `https://t.me/s/channel/num` as per [204](https://github.com/GateNLP/we-verify-app-assistant/issues/204).

This shouldn't be merged until the corresponding backend changes from [this PR](https://github.com/GateNLP/we-verify-app-assistant/pull/205) have been merged in.