### PR TITLE
Removed imageList filter

### DIFF
--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -793,10 +793,6 @@ const filterAssistantResults = (
     case KNOWN_LINKS.FACEBOOK:
       if (scrapeResult.videos.length === 0) {
         imageList = scrapeResult.images;
-        imageList = imageList.filter(
-          (imageUrl) =>
-            imageUrl.includes("//scontent") && !imageUrl.includes("/cp0/"),
-        );
       } else {
         videoList = scrapeResult.videos;
       }


### PR DESCRIPTION
Images extracted from facebook posts were being filtered based on their `src`. This meant that some facebook images posts weren't being picked up. I have removed this filter under the assumption that facebook have changed how they host images. If it becomes a problem, I propose we put the filter in the backend instead. This is partially implemented in https://github.com/GateNLP/we-verify-app-assistant/pull/211