### PR TITLE
Jmafoster1/213-bluesky support

### DIFF
--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -38,6 +38,7 @@ export const KNOWN_LINKS = {
   MASTODON: "mastodon",
   OWN: "own",
   VK: "vk",
+  BLUESKY: "bsky",
   MISC: "general",
 };
 
@@ -53,6 +54,10 @@ export const TYPE_PATTERNS = [
 ];
 
 export const KNOWN_LINK_PATTERNS = [
+  {
+    key: KNOWN_LINKS.BLUESKY,
+    patterns: ["((https?:/{2})?(www.)?(bsky).app/profile/[\\w.]+/post/\\w*)"],
+  },
   {
     key: KNOWN_LINKS.TWITTER,
     patterns: ["((https?:/{2})?(www.)?(twitter|x).com/\\w{1,15}/status/\\d*)"],

--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -296,6 +296,7 @@ export const ASSISTANT_ACTIONS = [
       KNOWN_LINKS.VIMEO,
       KNOWN_LINKS.LIVELEAK,
       KNOWN_LINKS.DAILYMOTION,
+      KNOWN_LINKS.BLUESKY,
     ],
     cTypes: [CONTENT_TYPE.VIDEO],
     exceptions: [],

--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -56,7 +56,7 @@ export const TYPE_PATTERNS = [
 export const KNOWN_LINK_PATTERNS = [
   {
     key: KNOWN_LINKS.BLUESKY,
-    patterns: ["((https?:/{2})?(www.)?(bsky).app/profile/[\\w.]+/post/\\w*)"],
+    patterns: ["((https?:/{2})?(www.)?(bsky).app/profile/[\\w-.]+/post/\\w*)"],
   },
   {
     key: KNOWN_LINKS.TWITTER,

--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -707,6 +707,7 @@ const decideWhetherToScrape = (urlType, contentType) => {
     case KNOWN_LINKS.INSTAGRAM:
     case KNOWN_LINKS.FACEBOOK:
     case KNOWN_LINKS.TWITTER:
+    case KNOWN_LINKS.BLUESKY:
     case KNOWN_LINKS.TELEGRAM:
     case KNOWN_LINKS.MASTODON:
     case KNOWN_LINKS.VK:
@@ -802,6 +803,14 @@ const filterAssistantResults = (
       }
       break;
     case KNOWN_LINKS.TWITTER:
+      if (scrapeResult.images.length > 0) {
+        imageList = scrapeResult.images;
+      }
+      if (scrapeResult.videos.length > 0) {
+        videoList = scrapeResult.videos;
+      }
+      break;
+    case KNOWN_LINKS.BLUESKY:
       if (scrapeResult.images.length > 0) {
         imageList = scrapeResult.images;
       }


### PR DESCRIPTION
Adds rules to direct the backend to scrape bluesky posts. Can be merged once https://github.com/GateNLP/we-verify-app-assistant/issues/213 has been merged and deployed