### PR TITLE
changed GET to POST request

### DIFF
--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
@@ -89,13 +89,13 @@ export default function assistantApiCalls() {
       }
     }
   }
-  
+
   const callSourceCredibilityService = async (urlList) => {
     return await callAsyncWithNumRetries(
       MAX_NUM_RETRIES,
       async () => {
         if (urlList.length === 0) return null;
-    
+
         let urls = urlList.join(" ");
 
         const result = await axios.post(
@@ -114,7 +114,7 @@ export default function assistantApiCalls() {
       },
     );
   };
-  
+
   const callNewsFramingService = async (text) => {
     return await callAsyncWithNumRetries(
       MAX_NUM_RETRIES,
@@ -225,11 +225,11 @@ export default function assistantApiCalls() {
     return await callAsyncWithNumRetries(
       MAX_NUM_RETRIES,
       async () => {
-        const result = await axios.get(
-          assistantEndpoint +
-            "kinit/machine-generated-text" +
-            "?text=" +
-            encodeURIComponent(text), // max URL length is 2048 characters
+        const result = await axios.post(
+          assistantEndpoint + "kinit/machine-generated-text",
+          {
+            content: text,
+          },
         );
         return result.data;
       },

--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
@@ -225,12 +225,6 @@ export default function assistantApiCalls() {
     return await callAsyncWithNumRetries(
       MAX_NUM_RETRIES,
       async () => {
-        // const result = await axios.get(
-        //   assistantEndpoint +
-        //     "kinit/machine-generated-text" +
-        //     "?text=" +
-        //     encodeURIComponent(text), // max URL length is 2048 characters
-        // );
         const result = await axios.post(
           assistantEndpoint + "kinit/machine-generated-text",
           {

--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
@@ -225,13 +225,13 @@ export default function assistantApiCalls() {
     return await callAsyncWithNumRetries(
       MAX_NUM_RETRIES,
       async () => {
-        const resultGet = await axios.get(
-          assistantEndpoint +
-            "kinit/machine-generated-text" +
-            "?text=" +
-            encodeURIComponent(text), // max URL length is 2048 characters
-        );
-        const resultPost = await axios.post(
+        // const result = await axios.get(
+        //   assistantEndpoint +
+        //     "kinit/machine-generated-text" +
+        //     "?text=" +
+        //     encodeURIComponent(text), // max URL length is 2048 characters
+        // );
+        const result = await axios.post(
           assistantEndpoint + "kinit/machine-generated-text",
           {
             content: text,

--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
@@ -225,7 +225,13 @@ export default function assistantApiCalls() {
     return await callAsyncWithNumRetries(
       MAX_NUM_RETRIES,
       async () => {
-        const result = await axios.post(
+        const resultGet = await axios.get(
+          assistantEndpoint +
+            "kinit/machine-generated-text" +
+            "?text=" +
+            encodeURIComponent(text), // max URL length is 2048 characters
+        );
+        const resultPost = await axios.post(
           assistantEndpoint + "kinit/machine-generated-text",
           {
             content: text,


### PR DESCRIPTION
For the machine generated text service, change from GET to POST request
- this will go through in the next frontend release
- need to allow backwards compatibility for current 0.83 version using GET - this is allowed in the backend