### PR TITLE
Filter undefined named entities

### DIFF
--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -538,10 +538,12 @@ function* handleNamedEntityCall(action) {
 
       Object.entries(result.response.annotations).forEach((entity) => {
         entity[1].forEach((instance) => {
-          entities.push({
-            word: instance.features.string,
-            category: entity[0],
-          });
+          if (instance.features.string) {
+            entities.push({
+              word: instance.features.string,
+              category: entity[0],
+            });
+          }
         });
       });
 


### PR DESCRIPTION
The named entity detector sometimes picks up undefined URLs. I made it so that only defined entities are displayed. Closes https://github.com/GateNLP/we-verify-app-assistant/issues/195

In the long term, it would be good to fix the root cause of this in the named entity recogniser.