### PR TITLE
Assistant - single results section

### DIFF
--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -3,7 +3,14 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { Grid2 } from "@mui/material";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Grid2,
+  IconButton,
+  Typography,
+} from "@mui/material";
 import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 
 import AssistantCheckStatus from "./AssistantCheckResults/AssistantCheckStatus";
@@ -25,6 +32,7 @@ import {
 } from "../../../redux/actions/tools/assistantActions";
 import { setError } from "redux/reducers/errorReducer";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { Close } from "@mui/icons-material";
 
 const Assistant = () => {
   // styles, language, dispatch, params
@@ -125,6 +133,13 @@ const Assistant = () => {
     }
   }, [url]);
 
+  // for having a single results section with a close button
+  const handleClose = () => {
+    //setFormInput("");
+    cleanAssistant();
+    dispatch(setUrlMode(true));
+  };
+
   return (
     <Grid2
       container
@@ -157,85 +172,110 @@ const Assistant = () => {
         </Grid2>
       ) : null}
 
-      {/* warnings and api status checks */}
-      {dbkfTextMatch || dbkfImageResult || dbkfVideoMatch ? (
-        <Grid2
-          size="grow"
-          className={classes.assistantGrid}
-          hidden={urlMode === null || urlMode === false}
-        >
-          <AssistantWarnings />
-        </Grid2>
-      ) : null}
+      {/* assistant results section */}
+      {urlMode && inputUrl ? (
+        <Card sx={{ width: "100%", mb: 2 }}>
+          <CardHeader
+            className={classes.assistantCardHeader}
+            title={
+              <Typography style={{ fontWeight: "bold", fontSize: 20 }}>
+                {keyword("Assistant results")}
+              </Typography>
+            }
+            action={
+              <IconButton aria-label="close" onClick={handleClose}>
+                <Close sx={{ color: "white" }} />
+              </IconButton>
+            }
+          />
 
-      {/* source crediblity//URL domain analysis results */}
-      {positiveSourceCred || cautionSourceCred || mixedSourceCred ? (
-        <Grid2 size="grow">
-          <AssistantSCResults />
-        </Grid2>
-      ) : null}
+          <CardContent>
+            <Grid2 container spacing={4}>
+              {/* assistant status */}
+              {scFailState ||
+              dbkfTextFailState ||
+              dbkfMediaFailState ||
+              neFailState ||
+              newsFramingFailState ||
+              newsGenreFailState ||
+              persuasionFailState ||
+              subjectivityFailState ||
+              previousFactChecksFailState ||
+              machineGeneratedTextFailState ? (
+                <Grid2 size={{ xs: 12 }}>
+                  <AssistantCheckStatus />
+                </Grid2>
+              ) : null}
 
-      {/* assistant status */}
-      {scFailState ||
-      dbkfTextFailState ||
-      dbkfMediaFailState ||
-      neFailState ||
-      newsFramingFailState ||
-      newsGenreFailState ||
-      persuasionFailState ||
-      subjectivityFailState ||
-      previousFactChecksFailState ||
-      machineGeneratedTextFailState ? (
-        <Grid2 size="grow">
-          <AssistantCheckStatus />
-        </Grid2>
-      ) : null}
+              {/* warnings and api status checks */}
+              {dbkfTextMatch || dbkfImageResult || dbkfVideoMatch ? (
+                <Grid2
+                  size={{ xs: 12 }}
+                  className={classes.assistantGrid}
+                  hidden={urlMode === null || urlMode === false}
+                >
+                  <AssistantWarnings />
+                </Grid2>
+              ) : null}
 
-      {/* media results */}
-      <Grid2
-        container
-        hidden={
-          !urlMode ||
-          (urlMode && inputUrl === null) ||
-          (urlMode &&
-            inputUrl !== null &&
-            !imageList.length &&
-            !videoList.length)
-        }
-      >
-        {imageList.length > 0 || videoList.length > 0 || imageVideoSelected ? (
-          <Grid2 size={{ xs: 12 }}>
-            <AssistantMediaResult />
-          </Grid2>
-        ) : null}
-      </Grid2>
+              {/* source crediblity//URL domain analysis results */}
+              {positiveSourceCred || cautionSourceCred || mixedSourceCred ? (
+                <Grid2 size={{ xs: 12 }}>
+                  <AssistantSCResults />
+                </Grid2>
+              ) : null}
 
-      {/* text results */}
-      {text ? (
-        <Grid2 size={{ xs: 12 }}>
-          <AssistantTextResult />
-        </Grid2>
-      ) : null}
+              {/* media results */}
+              <Grid2
+                container
+                hidden={
+                  !urlMode ||
+                  (urlMode && inputUrl === null) ||
+                  (urlMode &&
+                    inputUrl !== null &&
+                    !imageList.length &&
+                    !videoList.length)
+                }
+              >
+                {imageList.length > 0 ||
+                videoList.length > 0 ||
+                imageVideoSelected ? (
+                  <Grid2 size={{ xs: 12 }}>
+                    <AssistantMediaResult />
+                  </Grid2>
+                ) : null}
+              </Grid2>
 
-      {/* named entity results */}
-      {text && neResult ? (
-        <Grid2 size={{ xs: 12 }}>
-          <AssistantNEResult />
-        </Grid2>
-      ) : null}
+              {/* text results */}
+              {text ? (
+                <Grid2 size={{ xs: 12 }}>
+                  <AssistantTextResult />
+                </Grid2>
+              ) : null}
 
-      {/* extracted urls with url domain analysis */}
-      {text && linkList.length !== 0 ? (
-        <Grid2 size={{ xs: 12 }}>
-          <AssistantLinkResult />
-        </Grid2>
-      ) : null}
+              {/* named entity results */}
+              {text && neResult ? (
+                <Grid2 size={{ xs: 12 }}>
+                  <AssistantNEResult />
+                </Grid2>
+              ) : null}
 
-      {/* credibility signals */}
-      {text ? (
-        <Grid2 size={{ xs: 12 }}>
-          <AssistantCredSignals />
-        </Grid2>
+              {/* extracted urls with url domain analysis */}
+              {text && linkList.length !== 0 ? (
+                <Grid2 size={{ xs: 12 }}>
+                  <AssistantLinkResult />
+                </Grid2>
+              ) : null}
+
+              {/* credibility signals */}
+              {text ? (
+                <Grid2 size={{ xs: 12 }}>
+                  <AssistantCredSignals />
+                </Grid2>
+              ) : null}
+            </Grid2>
+          </CardContent>
+        </Card>
       ) : null}
     </Grid2>
   );

--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -172,6 +172,22 @@ const Assistant = () => {
         </Grid2>
       ) : null}
 
+      {/* assistant status */}
+      {scFailState ||
+      dbkfTextFailState ||
+      dbkfMediaFailState ||
+      neFailState ||
+      newsFramingFailState ||
+      newsGenreFailState ||
+      persuasionFailState ||
+      subjectivityFailState ||
+      previousFactChecksFailState ||
+      machineGeneratedTextFailState ? (
+        <Grid2 size={{ xs: 12 }}>
+          <AssistantCheckStatus />
+        </Grid2>
+      ) : null}
+
       {/* assistant results section */}
       {urlMode && inputUrl ? (
         <Card sx={{ width: "100%", mb: 2 }}>
@@ -191,22 +207,6 @@ const Assistant = () => {
 
           <CardContent>
             <Grid2 container spacing={4}>
-              {/* assistant status */}
-              {scFailState ||
-              dbkfTextFailState ||
-              dbkfMediaFailState ||
-              neFailState ||
-              newsFramingFailState ||
-              newsGenreFailState ||
-              persuasionFailState ||
-              subjectivityFailState ||
-              previousFactChecksFailState ||
-              machineGeneratedTextFailState ? (
-                <Grid2 size={{ xs: 12 }}>
-                  <AssistantCheckStatus />
-                </Grid2>
-              ) : null}
-
               {/* warnings and api status checks */}
               {dbkfTextMatch || dbkfImageResult || dbkfVideoMatch ? (
                 <Grid2


### PR DESCRIPTION
Put all results inside a single results section with a X close button
- followed example in Deepfake Video tool which has cards inside a main results section
- when X button is clicked, "Assistant results" section removed and "Give the URL..." section remains with an empty form

Questions:
- Are we happy with the order of the results?
    - Should the Warning section be outside the Assistant Results?
- I'm not sure on the historic reason why URL Domain Analysis is an outlined card instead of the same as the others - should they match? It also appears later as it takes time to load.

![image (81)](https://github.com/user-attachments/assets/12dbf9c5-a989-4539-b57b-23fb3b280a32)
