### PR TITLE
Jmafoster1/226 fix undefined language codes

### DIFF
--- a/src/components/Shared/Utils/languageUtils.jsx
+++ b/src/components/Shared/Utils/languageUtils.jsx
@@ -12,7 +12,7 @@ export const getLanguageName = (language, locale) => {
     // console.error(
     //   `Error: the language code ${language} is not ISO-639-1 compatible`,
     // );
-    return LanguageDictionary[language]["en"];
+    return LanguageDictionary["en"]["en"];
   }
   return LanguageDictionary[language][locale];
 };


### PR DESCRIPTION
Closes https://github.com/GateNLP/we-verify-app-assistant/issues/226

Currently, the twitter post https://x.com/hankgreen/status/1855718912887083225 breaks the assistant catastrophically because the language code is `zxx`, which is invalid. (I guess Twitter are using it for some specific purpose since the tweet only contains a link). I have changed it to default to English in such circumstances, which seemed to be the intended behaviour.