### PR TITLE
Jmafoster1/218 fix dbkf check

### DIFF
--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useDBKFApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useDBKFApi.jsx
@@ -9,7 +9,9 @@ export default function DBKFApi() {
         https://www.w3schools.com/tags/ref_urlencode.ASP. but this call can't seem to handle any "space" except %20.
         even %20%20 breaks it. >1 space/newlines/breaks etc. removed on server side for the time being.  */
     let finalUri =
-      dbkfAPI + "/claims?&limit=5&orderBy=score&q=" + encodeURIComponent(query);
+      dbkfAPI +
+      "/documents?&limit=5&orderBy=score&q=" +
+      encodeURIComponent(query);
     let searchResult = await axios.get(finalUri);
     let searchData = Object.values(searchResult.data);
     return searchData;

--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useDBKFApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useDBKFApi.jsx
@@ -21,8 +21,10 @@ export default function DBKFApi() {
       "/documents?&limit=5&orderBy=score&q=" +
       encodeURIComponent(cleanQuery(query));
     let searchResult = await axios.get(finalUri);
-    let searchData = Object.values(searchResult.data);
-    return searchData;
+    if (searchResult && searchResult.data) {
+      return searchResult.data.documents;
+    }
+    return [];
   };
 
   const callVideoSimilarityEndpoint = async (url) => {

--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useDBKFApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useDBKFApi.jsx
@@ -4,6 +4,14 @@ export default function DBKFApi() {
   const dbkfAPI = process.env.REACT_APP_DBKF_SEARCH_API;
   const similarityAPI = process.env.REACT_APP_DBKF_SIMILARITY_API;
 
+  function cleanQuery(query) {
+    // Remove the non alphanumeric suffixes, since the TextSimilarityEndpoint doesn't seem to like them
+    while (query.length > 0 && !/[a-zA-Z0-9]/.test(query[query.length - 1])) {
+      query = query.slice(0, -1);
+    }
+    return query;
+  }
+
   const callTextSimilarityEndpoint = async (query) => {
     /* if (... probably "when") this breaks: encodeURIComponent encodes line breaks, nbsp etc. according to utf-8
         https://www.w3schools.com/tags/ref_urlencode.ASP. but this call can't seem to handle any "space" except %20.
@@ -11,7 +19,7 @@ export default function DBKFApi() {
     let finalUri =
       dbkfAPI +
       "/documents?&limit=5&orderBy=score&q=" +
-      encodeURIComponent(query);
+      encodeURIComponent(cleanQuery(query));
     let searchResult = await axios.get(finalUri);
     let searchData = Object.values(searchResult.data);
     return searchData;

--- a/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Box from "@mui/material/Box";
+import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
@@ -43,14 +44,14 @@ const DbkfTextResults = () => {
                     component={"div"}
                     color={"textSecondary"}
                   >
-                    <a
-                      href={value.claimUrl}
+                    <Link
+                      href={value.externalLink}
                       key={key}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
                       {value.text}
-                    </a>
+                    </Link>
                   </Typography>
                 }
               />

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -83,6 +83,9 @@ const AssistantMediaResult = () => {
         image.onload = () => {
           resolve({ url: imageUrl, width: image.width, height: image.height });
         };
+        image.onerror = () => {
+          resolve({ url: imageUrl, width: null, height: null });
+        };
       });
     });
 
@@ -101,7 +104,7 @@ const AssistantMediaResult = () => {
   return (
     <Card
       data-testid="url-media-results"
-      hidden={!urlMode || (!imageList.length && !videoList.length)}
+      hidden={!urlMode || (!filteredImageList.length && !videoList.length)}
       //width={window.innerWidth}
     >
       <CardHeader

--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -384,7 +384,7 @@ function* handleDbkfTextCall(action) {
                 textToUse = text.slice(0, -1)
             }*/
       let result = yield call(dbkfAPI.callTextSimilarityEndpoint, textToUse);
-      let filteredResult = filterDbkfTextResult(result);
+      let filteredResult = result.length ? result : null;
 
       yield put(setDbkfTextMatchDetails(filteredResult, false, true, false));
     }
@@ -989,29 +989,6 @@ const addToRelevantSourceCred = (sourceCredList, result) => {
     credibilityEvidence: resultEvidence,
     credibilityScope: result["credibility-scope"],
   });
-};
-
-const filterDbkfTextResult = (result) => {
-  let resultList = [];
-  let scores = [];
-
-  result.forEach((res) => {
-    scores.push(res.score);
-  });
-
-  let scaled = scaleNumbers(scores, 0, 100);
-
-  // to be reviewed. only really fixes some minor cases.
-  result.forEach((value, index) => {
-    if (value.score > 1000 && scaled[index] > 70) {
-      resultList.push({
-        text: value.text,
-        claimUrl: value.externalLink,
-        score: value.score,
-      });
-    }
-  });
-  return resultList.length ? resultList : null;
 };
 
 const scaleNumbers = (unscaledNums) => {


### PR DESCRIPTION
Closes https://github.com/GateNLP/we-verify-app-assistant/issues/218
The text DBKF endpoint has changed from `/search/claims` to `/search/documents`. This PR changes this accordingly and removes the threshold for responses as per Nedelina's recommendation.