### PR TITLE
Assistant/chunking text cred signals

### DIFF
--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -488,8 +488,6 @@ function* handleSubjectivityCall(action) {
           textChunks[i],
         );
 
-        console.log(i, textChunkResult);
-
         // merge results
         if (i == 0) {
           result = textChunkResult;

--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -587,9 +587,10 @@ function* handlePrevFactChecksCall(action) {
         // merge results
         if (i == 0) {
           result = textChunkResult;
-        } else {
-          result.fact_checks.push(textChunkResult.textChunkResult);
         }
+        // else {
+        //   result.fact_checks.push(textChunkResult.textChunkResult);
+        // }
       }
 
       yield put(
@@ -647,9 +648,30 @@ function* handleMachineGeneratedTextCall(action) {
 
       console.log("MGT result=", result);
       // sum scores and divide each by length of textChunk
+      let overallResult = {
+        pred: null,
+        score: 0,
+      };
+      for (let i = 0; i < textChunks.length; i += 1) {
+        // loop through results and textChunks for length
+        overallResult.score += result[i].score * textChunks[i].length;
+        console.log(
+          i,
+          result[i].score,
+          textChunks[i].length,
+          result[i].score * textChunks[i].length,
+        );
+      }
+      console.log(
+        overallResult.score,
+        text.length,
+        overallResult.score / text.length,
+      );
+      overallResult.score = overallResult.score / text.length;
 
-      // should be done on backend?
-      yield put(setMachineGeneratedTextDetails(result[0], false, true, false));
+      yield put(
+        setMachineGeneratedTextDetails(overallResult, false, true, false),
+      );
     }
   } catch (error) {
     yield put(setMachineGeneratedTextDetails(null, false, false, true));


### PR DESCRIPTION
Apologies - this has sat here for a while! This is in regards to the long text issues, there was specifically a server timeout for this article below for the Subjectivity classifier only. However it now seems to work without the server timeout, so I'm not sure if this is still necessary to add?

Long text article: https://www.theatlantic.com/politics/archive/2024/10/trump-military-generals-hitler/680327/

Added chunking the text (6000 characters) and sending separately for DW subjectivity classifier 
- text is chunked 
- results for each chunk merged
- all results returned at the end 


For KInIT services, chunking not required:
- previous fact-checks is currently GET, but this is acceptable for how it works and they will be moving to POST in the near future after some experiments
- machine generated text is now POST, haven't seen the same issue as subjectivity


