### PR TITLE
Jmafoster1/66-text-entities

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -56,83 +56,26 @@ const AssistantNEResult = () => {
     });
   };
 
-  function getCallback(callback) {
-    return function (word, event) {
-      const isActive = callback !== "onWordMouseOut";
-      const element = event.target;
-      const text = select(element);
-      text
-        .on("click", () => {
-          if (isActive) {
-            window.open(`https://google.com/search?q=${word.text}`, "_blank");
-          }
-        })
-        .transition()
-        .attr("text-decoration", isActive ? "underline" : "none");
-    };
-  }
-
-  const options = {
-    rotations: 1,
-    rotationAngles: [0],
-    fontSizes: [15, 60],
-  };
-
-  const callbacks = {
-    getWordColor: (word) => {
-      switch (word.category.toLowerCase()) {
-        case "person":
-          return "blue";
-        case "location":
-          return "red";
-        case "organization":
-          return "green";
-        case "hashtag":
-          return "orange";
-        case "userid":
-          return "purple";
-        default:
-          return "black";
-      }
-    },
-    getWordTooltip: (word) => {
-      return word.text + " (" + word.category + "): " + word.value;
-    },
-    onWordClick: getCallback("onWordClick"),
-    onWordMouseOut: getCallback("onWordMouseOut"),
-    onWordMouseOver: getCallback("onWordMouseOver"),
-  };
-
-  function getWordColor(tag, active = true) {
-    if (active) {
-      switch (tag.category.toLowerCase()) {
-        case "person":
-          return "blue";
-        case "location":
-          return "red";
-        case "organization":
-          return "green";
-        case "hashtag":
-          return "orange";
-        case "userid":
-          return "purple";
-        default:
-          return "black";
-      }
-    }
+  function getWordColor(tag) {
     switch (tag.category.toLowerCase()) {
       case "person":
-        return "darkblue";
+        return "#648FFF";
+      // return "blue";
       case "location":
-        return "darkred";
+        return "#DC267F";
+      // return "red";
       case "organization":
-        return "darkgreen";
+        return "#FFB000";
+      // return "green";
       case "hashtag":
-        return "darkorange";
+        return "#FE6100";
+      // return "orange";
       case "userid":
-        return "darkpurple";
+        return "#785EF0";
+      // return "purple";
       default:
-        return "gray";
+        return "black";
+      // return "black";
     }
   }
 
@@ -203,13 +146,15 @@ const AssistantNEResult = () => {
           <ButtonGroup>
             {neResult.map((tag, index) => (
               <Button
+                className={
+                  visibleCategories[tag.category.toLowerCase()]
+                    ? classes.namedEntityButtonHidden
+                    : ""
+                }
                 style={{
                   color: "white",
                   border: "none",
-                  backgroundColor: getWordColor(
-                    tag,
-                    !visibleCategories[tag.category.toLowerCase()],
-                  ),
+                  backgroundColor: getWordColor(tag),
                 }}
                 key={tag.category}
                 onClick={() => toggleCategory(tag.category.toLowerCase())}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -88,9 +88,11 @@ const AssistantNEResult = () => {
   const customRenderer = (tag, size, color) => {
     const { className, style, ...props } = tag.props || {};
     const fontSize = size + "px";
-    const key = tag.key || tag.value;
     const tagStyle = {
       ...styles,
+      "&:hover": {
+        color: "red !important",
+      },
       color: getWordColor(tag),
       textDecorationColor: getWordColor(tag),
       visibility: visibleCategories[tag.category.toLowerCase()]
@@ -100,22 +102,23 @@ const AssistantNEResult = () => {
       ...style,
     };
 
-    let tagClassName = "tag-cloud-tag";
+    let tagClassName = classes.tagCloudTag;
     if (className) {
       tagClassName += " " + className;
     }
 
     return (
-      <Link
-        key={key}
-        style={tagStyle}
-        className={tagClassName}
-        href={"https://www.google.com/search?q=" + tag.value}
-        rel="noopener noreferrer"
-        target={"_blank"}
-      >
-        {tag.value}
-      </Link>
+      <Tooltip key={tag.key || tag.value} title={tag.count} arrow>
+        <Link
+          style={tagStyle}
+          className={tagClassName}
+          href={"https://www.google.com/search?q=" + tag.value}
+          rel="noopener noreferrer"
+          target={"_blank"}
+        >
+          {tag.value}
+        </Link>
+      </Tooltip>
     );
   };
 
@@ -168,7 +171,6 @@ const AssistantNEResult = () => {
               <TagCloud
                 tags={neResultCount}
                 shuffle={false}
-                key={JSON.stringify(visibleCategories)} // This key will change when filteredData changes
                 minSize={20}
                 maxSize={45}
                 renderer={customRenderer}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -13,9 +13,6 @@ import { ExpandLess, ExpandMore } from "@mui/icons-material";
 import LinearProgress from "@mui/material/LinearProgress";
 import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
-import ListItem from "@mui/material/ListItem";
-import List from "@mui/material/List";
-import ListItemText from "@mui/material/ListItemText";
 //import ReactWordcloud from "react-wordcloud";
 import { TagCloud } from "react-tagcloud";
 import { select } from "d3-selection";
@@ -151,7 +148,6 @@ const AssistantNEResult = () => {
       ...style,
     };
 
-    console.log(tag.value, tag.category, tagStyle);
     let tagClassName = "tag-cloud-tag";
     if (className) {
       tagClassName += " " + className;
@@ -191,6 +187,7 @@ const AssistantNEResult = () => {
                     !visibleCategories[tag.category.toLowerCase()],
                   ),
                 }}
+                key={tag.category}
                 onClick={() => toggleCategory(tag.category.toLowerCase())}
               >
                 {tag.category}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -146,7 +146,7 @@ const AssistantNEResult = () => {
         />
         {neLoading && <LinearProgress />}
         <CardContent>
-          <ButtonGroup>
+          <ButtonGroup sx={{ paddingBottom: "15px" }}>
             {neResult.map((tag, index) => (
               <Button
                 className={

--- a/src/components/Shared/MaterialUiStyles/useMyStyles.jsx
+++ b/src/components/Shared/MaterialUiStyles/useMyStyles.jsx
@@ -12,27 +12,13 @@ const styles = (theme) => ({
   },
 
   namedEntityButtonHidden: {
-    "text-decoration": "line-through !important",
-    "&:after": {
-      background: "rgba(0, 0, 0, 0.3)",
-      content: '" "',
-      position: "absolute",
-      top: 0,
-      bottom: 0,
-      left: 0,
-      right: 0,
-    },
-    "&.MuiButtonGroup-firstButton": {
-      "&:after": {
-        "border-top-left-radius": "4px",
-        "border-bottom-left-radius": "4px",
-      },
-    },
-    "&.MuiButtonGroup-lastButton": {
-      "&:after": {
-        "border-top-right-radius": "4px",
-        "border-bottom-right-radius": "4px",
-      },
+    textDecoration: "line-through !important",
+    filter: "brightness(80%)",
+  },
+
+  tagCloudTag: {
+    "&:hover": {
+      filter: "brightness(80%)",
     },
   },
 

--- a/src/components/Shared/MaterialUiStyles/useMyStyles.jsx
+++ b/src/components/Shared/MaterialUiStyles/useMyStyles.jsx
@@ -11,6 +11,31 @@ const styles = (theme) => ({
     textAlign: "center",
   },
 
+  namedEntityButtonHidden: {
+    "text-decoration": "line-through !important",
+    "&:after": {
+      background: "rgba(0, 0, 0, 0.3)",
+      content: '" "',
+      position: "absolute",
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    },
+    "&.MuiButtonGroup-firstButton": {
+      "&:after": {
+        "border-top-left-radius": "4px",
+        "border-bottom-left-radius": "4px",
+      },
+    },
+    "&.MuiButtonGroup-lastButton": {
+      "&:after": {
+        "border-top-right-radius": "4px",
+        "border-bottom-right-radius": "4px",
+      },
+    },
+  },
+
   rootNoCenter: {
     padding: theme.spacing(2),
   },

--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -560,6 +560,7 @@ function* handleNamedEntityCall(action) {
             return b.value - a.value;
           });
         });
+        categoryList.sort();
         yield put(
           setNeDetails(categoryList, wordCloudList, false, true, false),
         );


### PR DESCRIPTION
Text entities are now presented as a word cloud with counts visible on hover. Closes https://github.com/GateNLP/we-verify-app-assistant/issues/66 although a couple of backend points remain (see https://github.com/GateNLP/we-verify-app-assistant/issues/234 and https://github.com/GateNLP/we-verify-app-assistant/issues/233)
![image](https://github.com/user-attachments/assets/f265a9b1-4222-4a17-9236-a5fb2cd76602)
