### PR TITLE
Fixing missing instagram image

### DIFF
--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -230,25 +230,13 @@ const Assistant = () => {
               ) : null}
 
               {/* media results */}
-              <Grid2
-                container
-                hidden={
-                  !urlMode ||
-                  (urlMode && inputUrl === null) ||
-                  (urlMode &&
-                    inputUrl !== null &&
-                    !imageList.length &&
-                    !videoList.length)
-                }
-              >
-                {imageList.length > 0 ||
-                videoList.length > 0 ||
-                imageVideoSelected ? (
-                  <Grid2 size={{ xs: 12 }}>
-                    <AssistantMediaResult />
-                  </Grid2>
-                ) : null}
-              </Grid2>
+              {imageList.length > 0 ||
+              videoList.length > 0 ||
+              imageVideoSelected ? (
+                <Grid2 size={{ xs: 12 }}>
+                  <AssistantMediaResult />
+                </Grid2>
+              ) : null}
 
               {/* text results */}
               {text ? (

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -24,7 +24,7 @@ import {
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import VideoGridList from "../../../Shared/VideoGridList/VideoGridList";
-import { WarningAmber } from "@mui/icons-material";
+import { WarningOutlined } from "@mui/icons-material";
 
 import {
   TransHtmlDoubleLinkBreak,
@@ -87,6 +87,7 @@ const AssistantMediaResult = () => {
       return new Promise((resolve) => {
         const image = new Image();
         image.src = imageUrl;
+        console.log("imageUrl=", imageUrl);
         image.onload = () => {
           resolve({ url: imageUrl, width: image.width, height: image.height });
         };
@@ -102,6 +103,7 @@ const AssistantMediaResult = () => {
           .filter((image) => image.width > 2 && image.height > 2)
           .map((image) => image.url);
         setFilteredImageList(filteredImages);
+        console.log(imageDimensions, filteredImages);
       })
       .catch((error) => {
         console.error("Assistant error loading images:", error);
@@ -111,8 +113,7 @@ const AssistantMediaResult = () => {
   return (
     <Card
       data-testid="url-media-results"
-      hidden={!urlMode || (!filteredImageList.length && !videoList.length)}
-      //width={window.innerWidth}
+      hidden={!filteredImageList.length && !videoList.length}
     >
       <CardHeader
         className={classes.assistantCardHeader}

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -90,7 +90,7 @@ const AssistantMediaResult = () => {
         image.onload = () => {
           resolve({
             url: imageUrl,
-            include: image.width > 2 && image.height > 2,
+            include: image.width > 2 || image.height > 2,
           });
         };
         image.onerror = () => {

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -87,12 +87,16 @@ const AssistantMediaResult = () => {
       return new Promise((resolve) => {
         const image = new Image();
         image.src = imageUrl;
-        console.log("imageUrl=", imageUrl);
         image.onload = () => {
-          resolve({ url: imageUrl, width: image.width, height: image.height });
+          resolve({
+            url: imageUrl,
+            include: image.width > 2 && image.height > 2,
+          });
         };
         image.onerror = () => {
-          resolve({ url: imageUrl, width: null, height: null });
+          // We have to include it if there's an error loading as we don't have enough info to filter it out
+          // Instagram seem to have some pretty aggressive security policies, so we get this there
+          resolve({ url: imageUrl, include: true });
         };
       });
     });
@@ -100,10 +104,9 @@ const AssistantMediaResult = () => {
     Promise.all(imagePromises)
       .then((imageDimensions) => {
         const filteredImages = imageDimensions
-          .filter((image) => image.width > 2 && image.height > 2)
+          .filter((image) => image.include)
           .map((image) => image.url);
         setFilteredImageList(filteredImages);
-        console.log(imageDimensions, filteredImages);
       })
       .catch((error) => {
         console.error("Assistant error loading images:", error);

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -179,6 +179,7 @@ const AssistantTextResult = () => {
             <div hidden={dbkfMatch === null}>
               <Tooltip title={keyword("text_warning")}>
                 <WarningOutlined
+                  color={"warning"}
                   className={classes.toolTipWarning}
                   onClick={() => {
                     dispatch(setWarningExpanded(!warningExpanded));


### PR DESCRIPTION
Instagram missing image: https://www.instagram.com/p/DEoOs6Hsv4S
- Card with image displays fine without being filtered
- The issue comes from the `useEffect()` where the image isn't being loaded correctly resulting in an error. This causes width and height to be set to null 
https://github.com/AFP-Medialab/verification-plugin/blob/f7d33b2dc4a27d87f1396c3c3f1cccda1b0d0eac/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx#L91-L96
- And so, the image isn't added to the `filteredImageList` which is used to display the images
https://github.com/AFP-Medialab/verification-plugin/blob/f7d33b2dc4a27d87f1396c3c3f1cccda1b0d0eac/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx#L102-L104

@jmafoster1 - I'm not sure how best to check for these errors to filter through the acceptable images instead like in this case? Or do you have a different idea for this?

Aside:
- tidying up how 'AssistantMediaResult' component is hidden
- making DBKF warning icons for text and image matching 