### PR TITLE
Now supporting birdwatch URLs

### DIFF
--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -61,7 +61,10 @@ export const KNOWN_LINK_PATTERNS = [
   },
   {
     key: KNOWN_LINKS.TWITTER,
-    patterns: ["((https?:/{2})?(www.)?(twitter|x).com/\\w{1,15}/status/\\d*)"],
+    patterns: [
+      "((https?:/{2})?(www.)?(twitter|x).com/\\w{1,15}/status/\\d*)",
+      "((https?:/{2})?(www.)?(twitter|x).com/i/birdwatch/t/\\d*)",
+    ],
   },
   {
     key: KNOWN_LINKS.TIKTOK,


### PR DESCRIPTION
Closes https://github.com/GateNLP/we-verify-app-assistant/issues/246.
We now allow birdwatch twitter links as well as normal ones.