### PR TITLE
Code cleanup

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,7 @@
   "importOrder": [
     "react",
     "@mui/material",
+    "@mui/material/(.*)",
     "@mui/icons-material",
     "@mui",
     "@mui-icons",

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,18 @@
 {
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "importOrder": [
+    "react",
+    "@mui",
+    "@mui-icons",
+    "<THIRD_PARTY_MODULES>",
+    "^[./]",
+    "^[.]/[^./]",
+    "^[.]/[^./]/(.*)$",
+    "^[.]/",
+    "<INTERNAL_MODULES>"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -7,7 +7,6 @@
     "@mui/material",
     "@mui/material/(.*)",
     "@mui/icons-material",
-    "@mui",
     "@mui-icons",
     "<THIRD_PARTY_MODULES>",
     "^[./]",

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,6 +4,8 @@
   "plugins": ["@trivago/prettier-plugin-sort-imports"],
   "importOrder": [
     "react",
+    "@mui/material",
+    "@mui/icons-material",
     "@mui",
     "@mui-icons",
     "<THIRD_PARTY_MODULES>",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,14 @@ export default [...compat.extends("eslint:recommended", "plugin:react/recommende
         react,
     },
 
+    settings: {
+      react: {
+        version: 'detect' // Or specify the exact version, e.g., '18.0'
+      }
+    },
+
+    files: ["**/*.jsx"],
+
     languageOptions: {
         globals: {
             ...globals.browser,

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "i18next-browser-languagedetector": "^8.0.0",
         "i18next-chained-backend": "^4.6.2",
         "i18next-http-backend": "^2.6.1",
+        "jscodeshift": "^17.1.2",
         "jwt-decode": "^4.0.0",
         "konva": "^9.3.15",
         "lodash": "^4.17.21",
@@ -112,7 +113,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -140,7 +140,6 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
       "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -150,7 +149,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -197,7 +195,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
       "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.24.7"
@@ -210,7 +207,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.24.7.tgz",
       "integrity": "sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.24.7",
@@ -224,7 +221,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
       "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.25.2",
@@ -241,7 +237,6 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
       "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
@@ -263,7 +258,7 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.2.tgz",
       "integrity": "sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
@@ -281,7 +276,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
       "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
@@ -298,7 +293,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
       "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.24.8",
@@ -325,7 +319,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
       "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.24.7",
@@ -344,7 +337,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
       "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.24.7"
@@ -354,10 +346,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
-      "dev": true,
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -367,7 +358,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.0.tgz",
       "integrity": "sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
@@ -385,7 +376,6 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
       "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.24.8",
@@ -403,7 +393,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
       "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.24.7",
@@ -417,7 +406,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
       "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.24.7",
@@ -446,10 +434,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
-      "dev": true,
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -459,7 +446,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.0.tgz",
       "integrity": "sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.0",
@@ -474,7 +461,6 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
       "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.0",
@@ -503,7 +489,7 @@
       "version": "7.25.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.3.tgz",
       "integrity": "sha512-wUrcsxZg6rqBXG05HG1FPYgsP6EvwF4WpBbxIpWIIYnH8wG0gzx3yZY3dtEHas4sTAOGkbTsc9EGPxwff8lRoA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8",
@@ -520,7 +506,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.0.tgz",
       "integrity": "sha512-Bm4bH2qsX880b/3ziJ8KD711LT7z4u8CFudmjqle65AZj/HNUFhEf90dqYv6O86buWvSBmeQDjv0Tn2aF/bIBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -536,7 +522,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.0.tgz",
       "integrity": "sha512-lXwdNZtTmeVOOFtwM/WDe7yg1PL8sYhRk/XH0FzbR2HDQ0xC+EnQ/JHeoMYSavtU115tnUk0q9CDyq8si+LMAA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -552,7 +538,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.24.7.tgz",
       "integrity": "sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -570,7 +556,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.0.tgz",
       "integrity": "sha512-tggFrk1AIShG/RUQbEwt2Tr/E+ObkfwrPjR6BjbRvsx24+PSjK8zrq0GWPNCjo8qpRx4DuJzlcvWJqlm+0h3kw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8",
@@ -587,7 +573,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -600,7 +586,7 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -613,7 +599,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -626,7 +612,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -642,7 +628,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
       "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -655,10 +641,25 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
       "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-flow": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz",
+      "integrity": "sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -668,7 +669,7 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.6.tgz",
       "integrity": "sha512-aABl0jHw9bZ2karQ/uUD6XP4u0SG22SJrOHFoL6XB1R7dTovOP4TzTlsxOYC5yQ1pdscVK2JTUnF6QL3ARoAiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -684,7 +685,7 @@
       "version": "7.25.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
       "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -700,7 +701,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -713,7 +714,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -726,7 +727,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
       "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -742,7 +742,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -755,7 +755,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
       "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -768,7 +767,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -781,7 +780,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -794,7 +793,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -807,7 +806,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
       "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -820,7 +818,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -836,7 +834,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -852,7 +850,6 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
       "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -868,7 +865,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
       "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
@@ -885,7 +882,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.7.tgz",
       "integrity": "sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -901,7 +898,7 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.4.tgz",
       "integrity": "sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8",
@@ -920,7 +917,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.24.7.tgz",
       "integrity": "sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.24.7",
@@ -938,7 +935,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.7.tgz",
       "integrity": "sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -954,7 +951,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.0.tgz",
       "integrity": "sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -970,7 +967,6 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz",
       "integrity": "sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.4",
@@ -987,7 +983,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.24.7.tgz",
       "integrity": "sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.24.7",
@@ -1005,7 +1001,7 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
       "integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
@@ -1026,7 +1022,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -1036,7 +1032,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.7.tgz",
       "integrity": "sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1053,7 +1049,7 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.8.tgz",
       "integrity": "sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -1069,7 +1065,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.24.7.tgz",
       "integrity": "sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.24.7",
@@ -1086,7 +1082,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.24.7.tgz",
       "integrity": "sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1102,7 +1098,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.0.tgz",
       "integrity": "sha512-YLpb4LlYSc3sCUa35un84poXoraOiQucUTTu8X1j18JV+gNa8E0nyUf/CjZ171IRGr4jEguF+vzJU66QZhn29g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.0",
@@ -1119,7 +1115,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.24.7.tgz",
       "integrity": "sha512-sc3X26PhZQDb3JhORmakcbvkeInvxz+A8oda99lj7J60QRuPZvNAk9wQlTBS1ZynelDrDmTU4pw1tyc5d5ZMUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1136,7 +1132,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.24.7.tgz",
       "integrity": "sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.24.7",
@@ -1153,7 +1149,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.24.7.tgz",
       "integrity": "sha512-v0K9uNYsPL3oXZ/7F9NNIbAj2jv1whUEtyA6aujhekLs56R++JDQuzRcP2/z4WX5Vg/c5lE9uWZA0/iUoFhLTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1166,11 +1162,27 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-flow-strip-types": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.26.5.tgz",
+      "integrity": "sha512-eGK26RsbIkYUns3Y8qKl362juDDYK+wEdPGHGrhzUl6CewZFo55VZ7hg+CyMFU4dd5QQakBN86nBMpRsFpRvbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.26.5",
+        "@babel/plugin-syntax-flow": "^7.26.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-for-of": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.7.tgz",
       "integrity": "sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1187,7 +1199,7 @@
       "version": "7.25.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.1.tgz",
       "integrity": "sha512-TVVJVdW9RKMNgJJlLtHsKDTydjZAbwIsn6ySBPQaEAUU5+gVvlJt/9nRmqVbsV/IBanRjzWoaAQKLoamWVOUuA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.24.8",
@@ -1205,7 +1217,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.24.7.tgz",
       "integrity": "sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1222,7 +1234,7 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.2.tgz",
       "integrity": "sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -1238,7 +1250,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.24.7.tgz",
       "integrity": "sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1255,7 +1267,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.7.tgz",
       "integrity": "sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1271,7 +1283,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.24.7.tgz",
       "integrity": "sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.24.7",
@@ -1288,7 +1300,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
       "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.24.8",
@@ -1306,7 +1317,7 @@
       "version": "7.25.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.0.tgz",
       "integrity": "sha512-YPJfjQPDXxyQWg/0+jHKj1llnY5f/R6a0p/vP4lPymxLu7Lvl4k2WMitqi08yxwQcCVUUdG9LCUj4TNEgAp3Jw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.0",
@@ -1325,7 +1336,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.24.7.tgz",
       "integrity": "sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.24.7",
@@ -1342,7 +1353,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.24.7.tgz",
       "integrity": "sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.24.7",
@@ -1359,7 +1370,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.24.7.tgz",
       "integrity": "sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1375,7 +1386,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.24.7.tgz",
       "integrity": "sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1392,7 +1402,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.24.7.tgz",
       "integrity": "sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1409,7 +1419,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.24.7.tgz",
       "integrity": "sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.24.7",
@@ -1428,7 +1438,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.7.tgz",
       "integrity": "sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1445,7 +1455,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.24.7.tgz",
       "integrity": "sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1462,7 +1472,6 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.24.8.tgz",
       "integrity": "sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8",
@@ -1480,7 +1489,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.7.tgz",
       "integrity": "sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1496,7 +1505,6 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz",
       "integrity": "sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.4",
@@ -1513,7 +1521,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.24.7.tgz",
       "integrity": "sha512-9z76mxwnwFxMyxZWEgdgECQglF2Q7cFLm0kMf8pGwt+GSJsY0cONKj/UuO4bOH0w/uAel3ekS4ra5CEAyJRmDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
@@ -1532,7 +1540,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.7.tgz",
       "integrity": "sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1665,7 +1673,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.24.7.tgz",
       "integrity": "sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1682,7 +1690,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.24.7.tgz",
       "integrity": "sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1698,7 +1706,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.7.tgz",
       "integrity": "sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1714,7 +1722,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.7.tgz",
       "integrity": "sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -1731,7 +1739,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.24.7.tgz",
       "integrity": "sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1747,7 +1755,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz",
       "integrity": "sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1763,7 +1771,7 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.24.8.tgz",
       "integrity": "sha512-adNTUpDCVnmAE58VEqKlAA6ZBlNkMnWD0ZcW76lyNFN3MJniyGFZfNwERVk8Ap56MCnXztmDr19T4mPTztcuaw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8"
@@ -1779,7 +1787,6 @@
       "version": "7.25.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
       "integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
@@ -1799,7 +1806,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.24.7.tgz",
       "integrity": "sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1815,7 +1822,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.24.7.tgz",
       "integrity": "sha512-uH2O4OV5M9FZYQrwc7NdVmMxQJOCCzFeYudlZSzUAHRFeOujQefa92E74TQDVskNHCzOXoigEuoyzHDhaEaK5w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.24.7",
@@ -1832,7 +1839,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.24.7.tgz",
       "integrity": "sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.24.7",
@@ -1849,7 +1856,7 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.4.tgz",
       "integrity": "sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.2",
@@ -1866,7 +1873,7 @@
       "version": "7.25.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.4.tgz",
       "integrity": "sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.25.4",
@@ -1960,11 +1967,28 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/preset-flow": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.25.9.tgz",
+      "integrity": "sha512-EASHsAhE+SSlEzJ4bzfusnXSHiU+JfAYzj+jbw2vgQKgq5HrUr8qs+vgtiEL5dOH6sEweI+PNt2D7AqrDSHyqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-transform-flow-strip-types": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -2000,7 +2024,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
       "integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7",
@@ -2016,11 +2039,148 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/register": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.9.tgz",
+      "integrity": "sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.6",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/register/node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/register/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/register/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/register/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/@babel/regjsgen": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
@@ -5709,6 +5869,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -5855,7 +6027,7 @@
       "version": "0.4.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
       "integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
@@ -5870,7 +6042,7 @@
       "version": "0.10.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
       "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.2",
@@ -5884,7 +6056,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
       "integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.2"
@@ -6081,7 +6253,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -6101,7 +6272,6 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
       "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6168,7 +6338,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bytes": {
@@ -6262,7 +6431,6 @@
       "version": "1.0.30001664",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
       "integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6530,7 +6698,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
       "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-plain-object": "^2.0.4",
@@ -6605,6 +6772,12 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "license": "MIT"
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -6831,7 +7004,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -6879,7 +7051,7 @@
       "version": "3.38.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
       "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "browserslist": "^4.23.3"
@@ -8272,7 +8444,6 @@
       "version": "1.5.29",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz",
       "integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -8598,7 +8769,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9009,7 +9179,6 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
-      "optional": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -9452,7 +9621,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -9567,6 +9735,15 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/flow-parser": {
+      "version": "0.259.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.259.1.tgz",
+      "integrity": "sha512-xiXLmMH2Z7OmdE9Q+MjljUMr/rbemFqZIRxaeZieVScG4HzQrKKhNcCYZbWTGpoN7ZPi7z8ClQbeVPq6t5AszQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -9781,7 +9958,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -10019,7 +10195,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/handle-thing": {
@@ -10726,7 +10901,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -11097,7 +11271,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -11145,7 +11318,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -11348,7 +11520,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11460,6 +11631,46 @@
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/jscodeshift": {
+      "version": "17.1.2",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-17.1.2.tgz",
+      "integrity": "sha512-uime4vFOiZ1o3ICT4Sm/AbItHEVw2oCxQ3a0egYVy3JMMOctxe07H3SKL1v175YqjMt27jn1N+3+Bj9SKDNgdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.7",
+        "@babel/parser": "^7.24.7",
+        "@babel/plugin-transform-class-properties": "^7.24.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+        "@babel/plugin-transform-optional-chaining": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/preset-flow": "^7.24.7",
+        "@babel/preset-typescript": "^7.24.7",
+        "@babel/register": "^7.24.6",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.7",
+        "neo-async": "^2.5.0",
+        "picocolors": "^1.0.1",
+        "recast": "^0.23.9",
+        "tmp": "^0.2.3",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "jscodeshift": "bin/jscodeshift.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@babel/preset-env": "^7.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/preset-env": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsdom": {
       "version": "15.2.1",
@@ -11614,7 +11825,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -11691,7 +11901,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12336,7 +12545,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -12567,7 +12776,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -12666,7 +12874,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -12948,7 +13155,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/no-case": {
@@ -12996,7 +13202,6 @@
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
       "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -13432,7 +13637,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13583,7 +13787,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -13613,6 +13816,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/pkg-dir": {
@@ -14452,6 +14664,31 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recast": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.9.tgz",
+      "integrity": "sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -14527,14 +14764,14 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
       "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
       "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2"
@@ -14553,7 +14790,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
       "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4"
@@ -14581,7 +14818,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
       "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/regjsgen": "^0.8.0",
@@ -14599,7 +14836,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
       "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~0.5.0"
@@ -14612,7 +14849,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "jsesc": "bin/jsesc"
       }
@@ -15219,7 +15456,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15452,7 +15688,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
       "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kind-of": "^6.0.2"
@@ -15678,7 +15913,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -15689,7 +15923,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -16251,6 +16484,12 @@
       "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
       "license": "MIT"
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tippy.js": {
       "version": "6.3.7",
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
@@ -16273,7 +16512,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
       "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -16283,7 +16521,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -16384,7 +16621,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tui-code-snippet": {
@@ -16634,7 +16870,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16644,7 +16880,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
@@ -16658,7 +16894,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
       "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16668,7 +16904,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -16721,7 +16957,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
       "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -17573,6 +17808,31 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -17623,7 +17883,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "@playwright/test": "^1.47.2",
         "@svgr/webpack": "^8.1.0",
         "@tanstack/eslint-plugin-query": "^5.61.6",
+        "@trivago/prettier-plugin-sort-imports": "^5.2.1",
         "@types/node": "^22.7.2",
         "babel-loader": "^9.2.1",
         "concurrently": "^9.0.1",
@@ -122,12 +123,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -176,15 +178,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
-      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+      "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6",
+        "@babel/parser": "^7.26.5",
+        "@babel/types": "^7.26.5",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -425,18 +428,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -481,28 +484,13 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/parser": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+      "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6"
+        "@babel/types": "^7.26.5"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2048,30 +2036,30 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
-      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+      "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.6",
-        "@babel/parser": "^7.25.6",
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.6",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.5",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.5",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2089,14 +2077,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+      "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4412,6 +4399,41 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.1.tgz",
+      "integrity": "sha512-NDZndt0fmVThIx/8cExuJHLZagUVzfGCoVrwH9x6aZvwfBdkrDFTYujecek6X2WpG4uUFsVaPg5+aNQPSyjcmw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "^7.26.2",
+        "@babel/parser": "^7.26.2",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "javascript-natural-sort": "^0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">18.12"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x",
+        "prettier-plugin-svelte": "3.x",
+        "svelte": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -5451,18 +5473,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -6313,29 +6323,6 @@
         "node": "*"
       }
     },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chalk/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/chart.js": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.4.tgz",
@@ -6562,21 +6549,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -10091,15 +10063,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
@@ -11424,6 +11387,13 @@
         "react": ">=18.0"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -11588,15 +11558,15 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -15979,18 +15949,6 @@
         "stylis": "4.x"
       }
     },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -16319,15 +16277,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@playwright/test": "^1.47.2",
     "@svgr/webpack": "^8.1.0",
     "@tanstack/eslint-plugin-query": "^5.61.6",
+    "@trivago/prettier-plugin-sort-imports": "^5.2.1",
     "@types/node": "^22.7.2",
     "babel-loader": "^9.2.1",
     "concurrently": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "webpack-merge": "^5.9.0"
   },
   "lint-staged": {
-    "src/**/*.{js,css,md,jsx}": "prettier --write"
+    "src/**/*.{js,css,md}": ["prettier --write"],
+    "src/**/*.jsx": ["prettier --write", "jscodeshift"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-chained-backend": "^4.6.2",
     "i18next-http-backend": "^2.6.1",
+    "jscodeshift": "^17.1.2",
     "jwt-decode": "^4.0.0",
     "konva": "^9.3.15",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,6 @@
   },
   "lint-staged": {
     "src/**/*.{js,css,md}": ["prettier --write"],
-    "src/**/*.jsx": ["prettier --write", "jscodeshift"]
+    "src/**/*.jsx": ["jscodeshift", "prettier --write"]
   }
 }

--- a/src/components/Feedback/Feedback.jsx
+++ b/src/components/Feedback/Feedback.jsx
@@ -1,20 +1,23 @@
 import * as React from "react";
 import { useState } from "react";
-import QuestionAnswerOutlinedIcon from "@mui/icons-material/QuestionAnswerOutlined";
+
 import Box from "@mui/material/Box";
-import Stack from "@mui/material/Stack";
-import Paper from "@mui/material/Paper";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
-import ToggleButton from "@mui/material/ToggleButton";
-import Typography from "@mui/material/Typography";
-import TextField from "@mui/material/TextField";
 import Fab from "@mui/material/Fab";
-import CloseIcon from "@mui/icons-material/Close";
+import Fade from "@mui/material/Fade";
 import IconButton from "@mui/material/IconButton";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { Fade } from "@mui/material";
+import Paper from "@mui/material/Paper";
 import Slide from "@mui/material/Slide";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Typography from "@mui/material/Typography";
+
+import CloseIcon from "@mui/icons-material/Close";
+import QuestionAnswerOutlinedIcon from "@mui/icons-material/QuestionAnswerOutlined";
+
 import LoadingButton from "@mui/lab/LoadingButton";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
 const Feedback = () => {
   const keyword = i18nLoadNamespace("components/FeedBack");

--- a/src/components/MainContent/index.jsx
+++ b/src/components/MainContent/index.jsx
@@ -1,21 +1,26 @@
 import React from "react";
-import MainContentMenuTopMenuItems from "../NavBar/MainContentMenuTabItems/MainContentMenuTopMenuItems";
-import ScrollTop from "../Shared/ScrollTop/ScrollTop";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import { Button, Fab, Snackbar } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+
+import Button from "@mui/material/Button";
+import Fab from "@mui/material/Fab";
+import Snackbar from "@mui/material/Snackbar";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
 import { KeyboardArrowUp } from "@mui/icons-material";
-import MySnackbar from "../MySnackbar/MySnackbar";
+
+import { canUserSeeTool } from "../../constants/tools";
+import { TOP_MENU_ITEMS } from "../../constants/topMenuItems";
+import { setFalse, setTrue } from "../../redux/reducers/cookiesReducers";
 import {
   cleanError,
   cleanErrorNetwork,
 } from "../../redux/reducers/errorReducer";
-import { setFalse, setTrue } from "../../redux/reducers/cookiesReducers";
 import Feedback from "../Feedback/Feedback";
-import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
-import { canUserSeeTool } from "../../constants/tools";
-import { useDispatch, useSelector } from "react-redux";
+import MySnackbar from "../MySnackbar/MySnackbar";
+import MainContentMenuTopMenuItems from "../NavBar/MainContentMenuTabItems/MainContentMenuTopMenuItems";
 import { i18nLoadNamespace } from "../Shared/Languages/i18nLoadNamespace";
-import { TOP_MENU_ITEMS } from "../../constants/topMenuItems";
+import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
+import ScrollTop from "../Shared/ScrollTop/ScrollTop";
 
 /**
  *

--- a/src/components/NavBar/DrawerItem/DrawerItem.jsx
+++ b/src/components/NavBar/DrawerItem/DrawerItem.jsx
@@ -1,16 +1,18 @@
 import React, { useEffect } from "react";
-import { Container } from "@mui/material";
-import Fade from "@mui/material/Fade";
 import { useDispatch, useSelector } from "react-redux";
 import { Route, Routes, useLocation } from "react-router-dom";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import { getclientId } from "../../Shared/GoogleAnalytics/MatomoAnalytics";
+
+import Container from "@mui/material/Container";
+import Fade from "@mui/material/Fade";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
 import { useTrackPageView } from "../../../Hooks/useAnalytics";
-import { selectTopMenuItem } from "../../../redux/reducers/navReducer";
-import { TOP_MENU_ITEMS } from "../../../constants/topMenuItems";
-import { selectTool } from "../../../redux/reducers/tools/toolReducer";
 import { TOOL_GROUPS, toolsHome } from "../../../constants/tools";
+import { TOP_MENU_ITEMS } from "../../../constants/topMenuItems";
+import { selectTopMenuItem } from "../../../redux/reducers/navReducer";
+import { selectTool } from "../../../redux/reducers/tools/toolReducer";
+import { getclientId } from "../../Shared/GoogleAnalytics/MatomoAnalytics";
+import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 
 /**
  *

--- a/src/components/NavBar/MainContentMenuTabItems/MainContentMenuTopMenuItems.jsx
+++ b/src/components/NavBar/MainContentMenuTabItems/MainContentMenuTopMenuItems.jsx
@@ -1,13 +1,15 @@
-import { Route, Routes, useLocation } from "react-router-dom";
-import { Container } from "@mui/material";
-import Fade from "@mui/material/Fade";
 import React, { useEffect } from "react";
-import DrawerItem from "../DrawerItem/DrawerItem";
 import { useDispatch, useSelector } from "react-redux";
+import { Route, Routes, useLocation } from "react-router-dom";
+
+import Container from "@mui/material/Container";
+import Fade from "@mui/material/Fade";
+
 import { useTrackPageView } from "../../../Hooks/useAnalytics";
 import { toolsHome } from "../../../constants/tools";
 import { TOP_MENU_ITEMS } from "../../../constants/topMenuItems";
 import { selectTopMenuItem } from "../../../redux/reducers/navReducer";
+import DrawerItem from "../DrawerItem/DrawerItem";
 
 /**
  * Represents the group of tools to display and their tabs in the ToolsMenu

--- a/src/components/NavItems/About/About.jsx
+++ b/src/components/NavItems/About/About.jsx
@@ -1,27 +1,31 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Grid2, Paper } from "@mui/material";
+
 import Box from "@mui/material/Box";
-import CustomTile from "../../Shared/CustomTitle/CustomTitle";
-import europeImage from "./images/logo_EUh2020_horizontal.png";
-import itiImage from "./images/iti.jpg";
-import afpImage from "./images/Logo-AFP-384.png";
-import afcnLogo from "./images/afcn_logo.png";
-import arijLogo from "./images/arij_logo.png";
 import Checkbox from "@mui/material/Checkbox";
 import FormControlLabel from "@mui/material/FormControlLabel";
+import Grid2 from "@mui/material/Grid2";
+import Link from "@mui/material/Link";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import {
   toggleHumanRightsCheckBox,
   toggleUnlockExplanationCheckBox,
 } from "../../../redux/actions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
-import Link from "@mui/material/Link";
-import Typography from "@mui/material/Typography";
 import {
   toggleAnalyticsCheckBox,
   toggleState,
 } from "../../../redux/reducers/cookiesReducers";
+import CustomTile from "../../Shared/CustomTitle/CustomTitle";
+import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
+import afpImage from "./images/Logo-AFP-384.png";
+import afcnLogo from "./images/afcn_logo.png";
+import arijLogo from "./images/arij_logo.png";
+import itiImage from "./images/iti.jpg";
+import europeImage from "./images/logo_EUh2020_horizontal.png";
 
 const About = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from "react";
-
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { Close } from "@mui/icons-material";
 import {
   Card,
   CardContent,
@@ -11,29 +11,28 @@ import {
   IconButton,
   Typography,
 } from "@mui/material";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 
-import AssistantCheckStatus from "./AssistantCheckResults/AssistantCheckStatus";
-import AssistantFileSelected from "./AssistantFileSelected";
-import AssistantIntroduction from "./AssistantIntroduction";
-import AssistantLinkResult from "./AssistantScrapeResults/AssistantLinkResult";
-import AssistantMediaResult from "./AssistantScrapeResults/AssistantMediaResult";
-import AssistantNEResult from "./AssistantCheckResults/AssistantNEResult";
-import AssistantSCResults from "./AssistantScrapeResults/AssistantSCResults";
-import AssistantTextResult from "./AssistantScrapeResults/AssistantTextResult";
-import AssistantUrlSelected from "./AssistantUrlSelected";
-import AssistantWarnings from "./AssistantScrapeResults/AssistantWarnings";
-import AssistantCredSignals from "./AssistantScrapeResults/AssistantCredibilitySignals";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { setError } from "redux/reducers/errorReducer";
+
 import { ROLES } from "../../../constants/roles.jsx";
-
 import {
   cleanAssistantState,
   setUrlMode,
   submitInputUrl,
 } from "../../../redux/actions/tools/assistantActions";
-import { setError } from "redux/reducers/errorReducer";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { Close } from "@mui/icons-material";
+import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
+import AssistantCheckStatus from "./AssistantCheckResults/AssistantCheckStatus";
+import AssistantNEResult from "./AssistantCheckResults/AssistantNEResult";
+import AssistantFileSelected from "./AssistantFileSelected";
+import AssistantIntroduction from "./AssistantIntroduction";
+import AssistantCredSignals from "./AssistantScrapeResults/AssistantCredibilitySignals";
+import AssistantLinkResult from "./AssistantScrapeResults/AssistantLinkResult";
+import AssistantMediaResult from "./AssistantScrapeResults/AssistantMediaResult";
+import AssistantSCResults from "./AssistantScrapeResults/AssistantSCResults";
+import AssistantTextResult from "./AssistantScrapeResults/AssistantTextResult";
+import AssistantWarnings from "./AssistantScrapeResults/AssistantWarnings";
+import AssistantUrlSelected from "./AssistantUrlSelected";
 
 const Assistant = () => {
   // styles, language, dispatch, params

--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { Close } from "@mui/icons-material";
 import {
   Card,
   CardContent,
@@ -11,6 +10,8 @@ import {
   IconButton,
   Typography,
 } from "@mui/material";
+
+import { Close } from "@mui/icons-material";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import { setError } from "redux/reducers/errorReducer";

--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -2,14 +2,12 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  Grid2,
-  IconButton,
-  Typography,
-} from "@mui/material";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
 
 import { Close } from "@mui/icons-material";
 

--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
@@ -47,7 +47,10 @@ export default function assistantApiCalls() {
   const callNamedEntityService = async (text, lang) => {
     const namedEntityResult = await axios.post(
       assistantEndpoint + "gcloud/named-entity",
-      { content: text, lang: lang },
+      {
+        content: text,
+        lang: lang,
+      },
     );
 
     return namedEntityResult.data;

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { IconButton } from "@mui/material";
-import { Alert } from "@mui/material";
+import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Collapse from "@mui/material/Collapse";
+import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus.jsx
@@ -1,17 +1,19 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import Box from "@mui/material/Box";
-import Collapse from "@mui/material/Collapse";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { IconButton } from "@mui/material";
-import Typography from "@mui/material/Typography";
-import { setStateExpanded } from "../../../../redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { Alert } from "@mui/material";
+import Box from "@mui/material/Box";
+import Collapse from "@mui/material/Collapse";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
-import { Alert } from "@mui/material";
+import Typography from "@mui/material/Typography";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { setStateExpanded } from "../../../../redux/actions/tools/assistantActions";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 
 const AssistantCheckStatus = () => {

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { IconButton } from "@mui/material";
 import { Alert } from "@mui/material";
 import Box from "@mui/material/Box";
@@ -10,6 +9,8 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -1,21 +1,23 @@
 import React, { useState } from "react";
+import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
+//import ReactWordcloud from "react-wordcloud";
+import { TagCloud } from "react-tagcloud";
 
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import { CardHeader, Grid2, Tooltip } from "@mui/material";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Card from "@mui/material/Card";
-import { CardHeader, Grid2, Tooltip } from "@mui/material";
 import CardContent from "@mui/material/CardContent";
 import LinearProgress from "@mui/material/LinearProgress";
 import Link from "@mui/material/Link";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-//import ReactWordcloud from "react-wordcloud";
-import { TagCloud } from "react-tagcloud";
-import "tippy.js/dist/tippy.css";
-import "tippy.js/animations/scale.css";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import "tippy.js/animations/scale.css";
+import "tippy.js/dist/tippy.css";
+
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import { Trans } from "react-i18next";
 import {
   TransHtmlDoubleLinkBreak,
   TransNamedEntityRecogniserLink,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -4,13 +4,15 @@ import { useSelector } from "react-redux";
 //import ReactWordcloud from "react-wordcloud";
 import { TagCloud } from "react-tagcloud";
 
-import { CardHeader, Grid2, Tooltip } from "@mui/material";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Grid2 from "@mui/material/Grid2";
 import LinearProgress from "@mui/material/LinearProgress";
 import Link from "@mui/material/Link";
+import Tooltip from "@mui/material/Tooltip";
 
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -1,25 +1,16 @@
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
 
-import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import Card from "@mui/material/Card";
-import { CardHeader, Grid2, ListItemButton, Tooltip } from "@mui/material";
+import { CardHeader, Grid2, Tooltip } from "@mui/material";
 import CardContent from "@mui/material/CardContent";
-import Collapse from "@mui/material/Collapse";
-import Divider from "@mui/material/Divider";
-import { ExpandLess, ExpandMore } from "@mui/icons-material";
 import LinearProgress from "@mui/material/LinearProgress";
-import Typography from "@mui/material/Typography";
 import Link from "@mui/material/Link";
-import ListItem from "@mui/material/ListItem";
-import List from "@mui/material/List";
-import ListItemText from "@mui/material/ListItemText";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 //import ReactWordcloud from "react-wordcloud";
 import { TagCloud } from "react-tagcloud";
-import { select } from "d3-selection";
 import "tippy.js/dist/tippy.css";
 import "tippy.js/animations/scale.css";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
@@ -38,10 +29,6 @@ const AssistantNEResult = () => {
   const neResultCount = useSelector((state) => state.assistant.neResultCount);
   const neLoading = useSelector((state) => state.assistant.neLoading);
 
-  const [selectedIndex, setSelectedIndex] = useState(null);
-  const handleCollapse = (index) => {
-    index === selectedIndex ? setSelectedIndex(null) : setSelectedIndex(index);
-  };
   const [visibleCategories, setVisibleCategories] = useState(
     neResult.reduce((acc, key) => {
       acc[key.category.toLowerCase()] = false;

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -4,7 +4,6 @@ import { useSelector } from "react-redux";
 //import ReactWordcloud from "react-wordcloud";
 import { TagCloud } from "react-tagcloud";
 
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { CardHeader, Grid2, Tooltip } from "@mui/material";
 import Button from "@mui/material/Button";
 import ButtonGroup from "@mui/material/ButtonGroup";
@@ -12,6 +11,8 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import LinearProgress from "@mui/material/LinearProgress";
 import Link from "@mui/material/Link";
+
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import "tippy.js/animations/scale.css";

--- a/src/components/NavItems/Assistant/AssistantCheckResults/DbkfMediaResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/DbkfMediaResults.jsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import { DuoOutlined } from "@mui/icons-material";
-import ImageIconOutlined from "@mui/icons-material/Image";
 import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
+
+import { DuoOutlined } from "@mui/icons-material";
+import ImageIconOutlined from "@mui/icons-material/Image";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantCheckResults/DbkfMediaResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/DbkfMediaResults.jsx
@@ -1,15 +1,15 @@
 import React from "react";
+import { useSelector } from "react-redux";
 
-import Box from "@mui/material/Box";
 import { DuoOutlined } from "@mui/icons-material";
 import ImageIconOutlined from "@mui/icons-material/Image";
+import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 
-import { useSelector } from "react-redux";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
 const DbkfMediaResults = () => {

--- a/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import TextFieldsIcon from "@mui/icons-material/TextFields";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import List from "@mui/material/List";
@@ -9,6 +8,8 @@ import ListItem from "@mui/material/ListItem";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
+
+import TextFieldsIcon from "@mui/icons-material/TextFields";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
@@ -1,15 +1,15 @@
 import React from "react";
+import { useSelector } from "react-redux";
 
+import TextFieldsIcon from "@mui/icons-material/TextFields";
 import Box from "@mui/material/Box";
 import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
-import TextFieldsIcon from "@mui/icons-material/TextFields";
 import Typography from "@mui/material/Typography";
 
-import { useSelector } from "react-redux";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
 const DbkfTextResults = () => {

--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
@@ -1,16 +1,18 @@
 import React, { useState } from "react";
 
-import { Chip, Grid2, Stack } from "@mui/material";
 import MuiAccordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
+import Chip from "@mui/material/Chip";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import Grid2 from "@mui/material/Grid2";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
+import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { styled } from "@mui/material/styles";

--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
@@ -1,9 +1,5 @@
 import React, { useState } from "react";
 
-import CloseIcon from "@mui/icons-material/Close";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 import { Chip, Grid2, Stack } from "@mui/material";
 import MuiAccordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
@@ -18,6 +14,11 @@ import ListItem from "@mui/material/ListItem";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { styled } from "@mui/material/styles";
+
+import CloseIcon from "@mui/icons-material/Close";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import CloseIcon from "@mui/icons-material/Close";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -8,7 +7,6 @@ import DialogTitle from "@mui/material/DialogTitle";
 import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import ListItemIcon from "@mui/material/ListItemIcon";
 import Link from "@mui/material/Link";
 import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 import Typography from "@mui/material/Typography";
@@ -17,14 +15,12 @@ import MuiAccordion from "@mui/material/Accordion";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import Box from "@mui/material/Box";
 import Tooltip from "@mui/material/Tooltip";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import { getUrlTypeFromCredScope } from "./assistantUtils";
 import { Chip, Grid2, Stack } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { Trans } from "react-i18next";
 import {
   TransHtmlDoubleLinkBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
@@ -1,31 +1,33 @@
 import React, { useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
+import { Chip, Grid2, Stack } from "@mui/material";
+import MuiAccordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import IconButton from "@mui/material/IconButton";
+import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import Link from "@mui/material/Link";
-import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
-import Typography from "@mui/material/Typography";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import MuiAccordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Tooltip from "@mui/material/Tooltip";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import { getUrlTypeFromCredScope } from "./assistantUtils";
-import { Chip, Grid2, Stack } from "@mui/material";
+import Typography from "@mui/material/Typography";
 import { styled } from "@mui/material/styles";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransHtmlDoubleLinkBreak,
   TransSourceCredibilityTooltip,
   TransUrlDomainAnalysisLink,
 } from "../TransComponents";
+import { getUrlTypeFromCredScope } from "./assistantUtils";
 
 const Accordion = styled((props) => (
   <MuiAccordion disableGutters elevation={0} square {...props} />

--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
@@ -45,13 +45,13 @@ const renderScope = (keyword, scope) => {
   return (
     <ListItem>
       {scope && scope.includes("/") ? (
-        <Typography variant={"subtitle2"}>
-          {` ${keyword("account_scope")} ${scope} `}
-        </Typography>
+        <Typography
+          variant={"subtitle2"}
+        >{` ${keyword("account_scope")} ${scope} `}</Typography>
       ) : scope ? (
-        <Typography variant={"subtitle2"}>
-          {` ${keyword("domain_scope")} ${scope} `}
-        </Typography>
+        <Typography
+          variant={"subtitle2"}
+        >{` ${keyword("domain_scope")} ${scope} `}</Typography>
       ) : null}
     </ListItem>
   );
@@ -61,9 +61,9 @@ const renderLabels = (keyword, labels) => {
   return (
     <ListItem>
       {labels ? (
-        <Typography variant={"subtitle2"}>
-          {` ${keyword("labelled_as")} ${labels} `}
-        </Typography>
+        <Typography
+          variant={"subtitle2"}
+        >{` ${keyword("labelled_as")} ${labels} `}</Typography>
       ) : null}
     </ListItem>
   );
@@ -73,9 +73,9 @@ const renderDescription = (keyword, description) => {
   return (
     <ListItem>
       {description ? (
-        <Typography variant={"subtitle2"}>
-          {` ${keyword("commented_as")} ${description} `}
-        </Typography>
+        <Typography
+          variant={"subtitle2"}
+        >{` ${keyword("commented_as")} ${description} `}</Typography>
       ) : null}
     </ListItem>
   );
@@ -213,9 +213,7 @@ const ExtractedSourceCredibilityDBKFDialog = ({
                                     {getUrlTypeFromCredScope(
                                       value.credibilityScope,
                                     )}
-                                    {` ${keyword(
-                                      "source_credibility_warning_account",
-                                    )} ${" "}${value.credibilitySource}`}
+                                    {` ${keyword("source_credibility_warning_account")} ${" "}${value.credibilitySource}`}
                                   </Typography>
                                 </Stack>
                               ) : value.credibilityScope ? (
@@ -229,9 +227,7 @@ const ExtractedSourceCredibilityDBKFDialog = ({
                                     sx={{ ml: 1 }}
                                     //color={trafficLightColor}
                                   >
-                                    {` ${keyword(
-                                      "source_credibility_warning_domain",
-                                    )} ${value.credibilitySource} `}
+                                    {` ${keyword("source_credibility_warning_domain")} ${value.credibilitySource} `}
                                   </Typography>
                                 </Stack>
                               ) : null}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityResult.jsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import Stack from "@mui/material/Stack";
 import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import ListItemText from "@mui/material/ListItemText";
 import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
-import ExtractedSourceCredibilityDBKFDialog from "./ExtractedSourceCredibilityDBKFDialog";
+import ListItemText from "@mui/material/ListItemText";
+import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+
+import ExtractedSourceCredibilityDBKFDialog from "./ExtractedSourceCredibilityDBKFDialog";
 
 const ExtractedSourceCredibilityResult = ({
   extractedSourceCredibilityResults,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
@@ -1,13 +1,15 @@
 import React, { useState } from "react";
 
-import { Chip, Grid2, Tooltip } from "@mui/material";
+import Chip from "@mui/material/Chip";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import Grid2 from "@mui/material/Grid2";
 import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
 import CloseIcon from "@mui/icons-material/Close";

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
@@ -1,8 +1,5 @@
 import React, { useState } from "react";
 
-import CloseIcon from "@mui/icons-material/Close";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 import { Chip, Grid2, Tooltip } from "@mui/material";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -12,6 +9,10 @@ import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import Typography from "@mui/material/Typography";
+
+import CloseIcon from "@mui/icons-material/Close";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import CloseIcon from "@mui/icons-material/Close";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
@@ -8,7 +7,6 @@ import DialogTitle from "@mui/material/DialogTitle";
 import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import ListItemIcon from "@mui/material/ListItemIcon";
 import Link from "@mui/material/Link";
 import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 import Typography from "@mui/material/Typography";

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
@@ -1,19 +1,21 @@
 import React, { useState } from "react";
 
 import CloseIcon from "@mui/icons-material/Close";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
+import { Chip, Grid2, Tooltip } from "@mui/material";
 import Dialog from "@mui/material/Dialog";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import IconButton from "@mui/material/IconButton";
+import Link from "@mui/material/Link";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import Link from "@mui/material/Link";
-import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 import Typography from "@mui/material/Typography";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import { Chip, Grid2, Tooltip } from "@mui/material";
 import {
   TransHtmlDoubleLinkBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
@@ -39,15 +39,11 @@ const SourceCredibilityResult = (props) => {
                         <Typography>
                           {` ${keyword("this")}`}
                           {getUrlTypeFromCredScope(value.credibilityScope)}
-                          {` ${keyword(
-                            "source_credibility_warning_account",
-                          )} ${" "}${value.credibilitySource}`}
+                          {` ${keyword("source_credibility_warning_account")} ${" "}${value.credibilitySource}`}
                         </Typography>
                       ) : value.credibilityScope ? (
                         <Typography>
-                          {` ${keyword(
-                            "source_credibility_warning_domain",
-                          )} ${" "}${value.credibilitySource}`}
+                          {` ${keyword("source_credibility_warning_domain")} ${" "}${value.credibilitySource}`}
                         </Typography>
                       ) : null}
                     </Typography>
@@ -62,29 +58,21 @@ const SourceCredibilityResult = (props) => {
                   >
                     {value.credibilityScope.includes("/") ? (
                       <Typography variant={"subtitle2"}>
-                        {` ${" "} ${keyword("account_scope")} ${
-                          value.credibilityScope
-                        } `}
+                        {` ${" "} ${keyword("account_scope")} ${value.credibilityScope} `}
                       </Typography>
                     ) : value.credibilityScope ? (
                       <Typography variant={"subtitle2"}>
-                        {` ${keyword("domain_scope")} ${
-                          value.credibilityScope
-                        } `}
+                        {` ${keyword("domain_scope")} ${value.credibilityScope} `}
                       </Typography>
                     ) : null}
                     {value.credibilityLabels ? (
                       <Typography variant={"subtitle2"}>
-                        {` ${keyword("labelled_as")} ${
-                          value.credibilityLabels
-                        } `}
+                        {` ${keyword("labelled_as")} ${value.credibilityLabels} `}
                       </Typography>
                     ) : null}
                     {value.credibilityDescription ? (
                       <Typography variant={"subtitle2"}>
-                        {` ${keyword("commented_as")} ${
-                          value.credibilityDescription
-                        } `}
+                        {` ${keyword("commented_as")} ${value.credibilityDescription} `}
                       </Typography>
                     ) : null}
                     {value.credibilityEvidence.length > 0 ? (

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
@@ -4,13 +4,11 @@ import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
-import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
 import SourceCredibilityDBKFDialog from "./SourceCredibilityDBKFDialog";
 import Typography from "@mui/material/Typography";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import { getUrlTypeFromCredScope } from "./assistantUtils";
-import { Chip, Grid2 } from "@mui/material";
 
 const SourceCredibilityResult = (props) => {
   // central
@@ -18,7 +16,6 @@ const SourceCredibilityResult = (props) => {
 
   // props
   const sourceCredibilityResults = props.scResultFiltered;
-  const Icon = props.icon;
   const iconColor = props.iconColor;
   const sourceType = props.sourceType;
 

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
@@ -3,11 +3,13 @@ import React from "react";
 import Box from "@mui/material/Box";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
-import ListItemText from "@mui/material/ListItemText";
 import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
-import SourceCredibilityDBKFDialog from "./SourceCredibilityDBKFDialog";
+import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import SourceCredibilityDBKFDialog from "./SourceCredibilityDBKFDialog";
 import { getUrlTypeFromCredScope } from "./assistantUtils";
 
 const SourceCredibilityResult = (props) => {

--- a/src/components/NavItems/Assistant/AssistantFileSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantFileSelected.jsx
@@ -2,10 +2,11 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-import { CardHeader, Grid2 } from "@mui/material";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Grid2 from "@mui/material/Grid2";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemAvatar from "@mui/material/ListItemAvatar";

--- a/src/components/NavItems/Assistant/AssistantFileSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantFileSelected.jsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
+import { CardHeader, Grid2 } from "@mui/material";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
-import { CardHeader, Grid2 } from "@mui/material";
 import CardContent from "@mui/material/CardContent";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -11,14 +12,14 @@ import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 import {
   CONTENT_TYPE,
   KNOWN_LINKS,
   selectCorrectActions,
 } from "./AssistantRuleBook";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
-import { useNavigate } from "react-router-dom";
 
 const AssistantFileSelected = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/Assistant/AssistantIntroduction.jsx
+++ b/src/components/NavItems/Assistant/AssistantIntroduction.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Box, CardHeader, Grid2 } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
-import Tooltip, { tooltipClasses } from "@mui/material/Tooltip";
+import Tooltip from "@mui/material/Tooltip";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import LinkIcon from "@mui/icons-material/Link";
@@ -21,13 +21,9 @@ import HeaderTool from "../../Shared/HeaderTool/HeaderTool";
 
 import {
   TransHtmlDoubleLinkBreak,
-  TransSupportedUrlsLink,
   TransSupportedToolsLink,
 } from "./TransComponents";
 import { Trans } from "react-i18next";
-import { Link } from "react-router-dom";
-
-import { styled } from "@mui/material/styles";
 
 const AssistantIntroduction = (props) => {
   // styles, language, dispatch, params

--- a/src/components/NavItems/Assistant/AssistantIntroduction.jsx
+++ b/src/components/NavItems/Assistant/AssistantIntroduction.jsx
@@ -2,14 +2,15 @@ import React, { useState } from "react";
 import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
-import LinkIcon from "@mui/icons-material/Link";
 import { Box, CardHeader, Grid2 } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
+import LinkIcon from "@mui/icons-material/Link";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantIntroduction.jsx
+++ b/src/components/NavItems/Assistant/AssistantIntroduction.jsx
@@ -2,9 +2,11 @@ import React, { useState } from "react";
 import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Box, CardHeader, Grid2 } from "@mui/material";
+import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Grid2 from "@mui/material/Grid2";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantIntroduction.jsx
+++ b/src/components/NavItems/Assistant/AssistantIntroduction.jsx
@@ -1,29 +1,29 @@
 import React, { useState } from "react";
+import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
+import LinkIcon from "@mui/icons-material/Link";
 import { Box, CardHeader, Grid2 } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Tooltip from "@mui/material/Tooltip";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
-import LinkIcon from "@mui/icons-material/Link";
 import Typography from "@mui/material/Typography";
 
-import AssistantIcon from "../../NavBar/images/navbar/assistant-icon-primary.svg";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import {
   setImageVideoSelected,
   setUrlMode,
 } from "../../../redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
+import AssistantIcon from "../../NavBar/images/navbar/assistant-icon-primary.svg";
 import HeaderTool from "../../Shared/HeaderTool/HeaderTool";
-
+import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransHtmlDoubleLinkBreak,
   TransSupportedToolsLink,
 } from "./TransComponents";
-import { Trans } from "react-i18next";
 
 const AssistantIntroduction = (props) => {
   // styles, language, dispatch, params

--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import DownloadIcon from "@mui/icons-material/Download";
 
 import { ROLES } from "../../../constants/roles.jsx";

--- a/src/components/NavItems/Assistant/AssistantRuleBook.jsx
+++ b/src/components/NavItems/Assistant/AssistantRuleBook.jsx
@@ -14,7 +14,6 @@ import {
   thumbnails,
   videoAnalysis,
   videoDeepfake,
-  videoRights,
 } from "../../../constants/tools";
 
 export const NE_SUPPORTED_LANGS = ["en", "pt", "fr", "de", "el", "es", "it"];

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
@@ -1,37 +1,37 @@
 import React, { useState } from "react";
+import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-import Card from "@mui/material/Card";
-import { CardHeader, Grid2, Skeleton, styled } from "@mui/material";
-import CardContent from "@mui/material/CardContent";
-import Accordion from "@mui/material/Accordion";
-import AccordionSummary from "@mui/material/AccordionSummary";
-import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import Remove from "@mui/icons-material/Remove";
-import Typography from "@mui/material/Typography";
-import Tooltip from "@mui/material/Tooltip";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import Remove from "@mui/icons-material/Remove";
+import { CardHeader, Grid2, Skeleton, styled } from "@mui/material";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 import Collapse from "@mui/material/Collapse";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 
+import GaugeChartResult from "components/Shared/GaugeChartResults/GaugeChartResult.jsx";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import dayjs from "dayjs";
 import LocaleData from "dayjs/plugin/localeData";
 import localizedFormat from "dayjs/plugin/localizedFormat";
 
-import ResultDisplayItem from "./../../tools/SemanticSearch/components/ResultDisplayItem.jsx";
 import { ROLES } from "../../../../constants/roles.jsx";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import { getLanguageName } from "../../../Shared/Utils/languageUtils";
-import TextFooterPrevFactChecks from "./TextFooter.jsx";
-import GaugeChartResult from "components/Shared/GaugeChartResults/GaugeChartResult.jsx";
 import {
   TransCredibilitySignalsLink,
   TransHtmlDoubleLinkBreak,
   TransHtmlSingleLinkBreak,
 } from "../TransComponents";
-import { Trans } from "react-i18next";
+import ResultDisplayItem from "./../../tools/SemanticSearch/components/ResultDisplayItem.jsx";
+import TextFooterPrevFactChecks from "./TextFooter.jsx";
 
 const getExpandIcon = (
   loading,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
@@ -3,9 +3,6 @@ import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import Remove from "@mui/icons-material/Remove";
 import { CardHeader, Grid2, Skeleton, styled } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
@@ -15,6 +12,10 @@ import CardContent from "@mui/material/CardContent";
 import Collapse from "@mui/material/Collapse";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import Remove from "@mui/icons-material/Remove";
 
 import GaugeChartResult from "components/Shared/GaugeChartResults/GaugeChartResult.jsx";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
@@ -3,6 +3,7 @@ import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
+import { styled } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
@@ -14,7 +15,6 @@ import Grid2 from "@mui/material/Grid2";
 import Skeleton from "@mui/material/Skeleton";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import styled from "@mui/material/styled";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
@@ -3,15 +3,18 @@ import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-import { CardHeader, Grid2, Skeleton, styled } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
 import Collapse from "@mui/material/Collapse";
+import Grid2 from "@mui/material/Grid2";
+import Skeleton from "@mui/material/Skeleton";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import styled from "@mui/material/styled";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
@@ -19,14 +19,12 @@ import dayjs from "dayjs";
 import LocaleData from "dayjs/plugin/localeData";
 import localizedFormat from "dayjs/plugin/localizedFormat";
 
-import AssistantTextClassification from "./AssistantTextClassification.jsx";
-import AssistantTextSpanClassification from "./AssistantTextSpanClassification.jsx";
 import ResultDisplayItem from "./../../tools/SemanticSearch/components/ResultDisplayItem.jsx";
 import { ROLES } from "../../../../constants/roles.jsx";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import { getLanguageName } from "../../../Shared/Utils/languageUtils";
-import TextFooter, { TextFooterPrevFactChecks } from "./TextFooter.jsx";
+import TextFooterPrevFactChecks from "./TextFooter.jsx";
 import GaugeChartResult from "components/Shared/GaugeChartResults/GaugeChartResult.jsx";
 import {
   TransCredibilitySignalsLink,
@@ -34,34 +32,6 @@ import {
   TransHtmlSingleLinkBreak,
 } from "../TransComponents";
 import { Trans } from "react-i18next";
-
-const renderEntityKeys = (entities, keyword) => {
-  // translate array into readable string
-  let translatedEntities = [];
-  Object.keys(entities).map((entity, index) =>
-    entity != "Important_Sentence"
-      ? translatedEntities.push(keyword(entity))
-      : null,
-  );
-  return translatedEntities.join("; ");
-};
-
-const round = (number, decimalPlaces) => {
-  return (Math.round(number * 100) / 100).toFixed(decimalPlaces);
-};
-
-const calculateSubjectivity = (sentences) => {
-  let scoresSUBJ = [];
-  for (let i = 0; i < sentences.length; i++) {
-    if (sentences[i].label == "SUBJ") {
-      scoresSUBJ.push(Number(sentences[i].score));
-    }
-  }
-
-  return [" (", scoresSUBJ.length, "/", sentences.length, ")"]
-    .toString()
-    .replaceAll(",", "");
-};
 
 const getExpandIcon = (
   loading,
@@ -85,12 +55,10 @@ const getExpandIcon = (
 
 const AssistantCredSignals = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");
-  const sharedKeyword = i18nLoadNamespace("components/Shared/utils");
   const classes = useMyStyles();
   const expandMinimiseText = keyword("expand_minimise_text");
 
   // displaying expanded text in AccordionDetails
-  const [displayOrigLang, setDisplayOrigLang] = useState(true);
   const [displayExpander, setDisplayExpander] = useState(true);
   const [expanded, setExpanded] = useState(true);
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantImageResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantImageResult.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import { IconButton } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
 import CardMedia from "@mui/material/CardMedia";
+import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantImageResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantImageResult.jsx
@@ -2,15 +2,17 @@ import React from "react";
 import { useSelector } from "react-redux";
 
 import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
-import Card from "@mui/material/Card";
-import CardActions from "@mui/material/CardActions";
-import CardMedia from "@mui/material/CardMedia";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
 import ImageIcon from "@mui/icons-material/Image";
 import { IconButton } from "@mui/material";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardMedia from "@mui/material/CardMedia";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 
 const AssistantImageResult = () => {

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantImageResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantImageResult.jsx
@@ -1,15 +1,16 @@
 import React from "react";
 import { useSelector } from "react-redux";
 
-import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
-import FileCopyIcon from "@mui/icons-material/FileCopy";
-import ImageIcon from "@mui/icons-material/Image";
 import { IconButton } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
 import CardMedia from "@mui/material/CardMedia";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
+
+import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
+import FileCopyIcon from "@mui/icons-material/FileCopy";
+import ImageIcon from "@mui/icons-material/Image";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -1,29 +1,17 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useSelector } from "react-redux";
 
 import Card from "@mui/material/Card";
-import {
-  Box,
-  Button,
-  CardHeader,
-  Chip,
-  Grid2,
-  Skeleton,
-  Stack,
-} from "@mui/material";
+import { Box, CardHeader, Chip, Skeleton, Stack } from "@mui/material";
 import CardContent from "@mui/material/CardContent";
 import Link from "@mui/material/Link";
-import LinkIcon from "@mui/icons-material/Link";
 import Typography from "@mui/material/Typography";
-import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
-import SentimentSatisfied from "@mui/icons-material/SentimentSatisfied";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import ExtractedSourceCredibilityResult from "../AssistantCheckResults/ExtractedSourceCredibilityResult";
 import { TextCopy } from "../../../Shared/Utils/TextCopy";
 import Tooltip from "@mui/material/Tooltip";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import { CheckCircleOutline, TaskAltOutlined } from "@mui/icons-material";
 import { DataGrid, getGridSingleSelectOperators } from "@mui/x-data-grid";
 import { Trans } from "react-i18next";
 import {

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -2,13 +2,15 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { Box, CardHeader, Chip, Skeleton, Stack } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+
 import { DataGrid, getGridSingleSelectOperators } from "@mui/x-data-grid";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -2,10 +2,14 @@ import React from "react";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 
-import { Box, CardHeader, Chip, Skeleton, Stack } from "@mui/material";
+import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Chip from "@mui/material/Chip";
 import Link from "@mui/material/Link";
+import Skeleton from "@mui/material/Skeleton";
+import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -1,19 +1,21 @@
 import React from "react";
+import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 
-import Card from "@mui/material/Card";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { Box, CardHeader, Chip, Skeleton, Stack } from "@mui/material";
+import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Link from "@mui/material/Link";
-import Typography from "@mui/material/Typography";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import ExtractedSourceCredibilityResult from "../AssistantCheckResults/ExtractedSourceCredibilityResult";
-import { TextCopy } from "../../../Shared/Utils/TextCopy";
 import Tooltip from "@mui/material/Tooltip";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import Typography from "@mui/material/Typography";
 import { DataGrid, getGridSingleSelectOperators } from "@mui/x-data-grid";
-import { Trans } from "react-i18next";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import { TextCopy } from "../../../Shared/Utils/TextCopy";
+import ExtractedSourceCredibilityResult from "../AssistantCheckResults/ExtractedSourceCredibilityResult";
 import {
   TransHtmlDoubleLinkBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -15,6 +15,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { CONTENT_TYPE } from "../AssistantRuleBook";
 import AssistantImageResult from "./AssistantImageResult";
 import AssistantVideoResult from "./AssistantVideoResult";
+import WarningAmber from "./AssistantWarnings";
 import AssistantProcessUrlActions from "./AssistantProcessUrlActions";
 import ImageGridList from "../../../Shared/ImageGridList/ImageGridList";
 import {
@@ -24,14 +25,12 @@ import {
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import VideoGridList from "../../../Shared/VideoGridList/VideoGridList";
-import { WarningOutlined } from "@mui/icons-material";
 
 import {
   TransHtmlDoubleLinkBreak,
   TransSupportedToolsLink,
 } from "../TransComponents";
 import { Trans } from "react-i18next";
-import { Link } from "react-router-dom";
 
 const AssistantMediaResult = () => {
   const classes = useMyStyles();
@@ -40,7 +39,6 @@ const AssistantMediaResult = () => {
 
   // assistant media states
   const processUrl = useSelector((state) => state.assistant.processUrl);
-  const urlMode = useSelector((state) => state.assistant.urlMode);
   const resultProcessType = useSelector(
     (state) => state.assistant.processUrlType,
   );

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from "react";
 import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import { CardHeader, Grid2, LinearProgress } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from "react";
 import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { CardHeader, Grid2, LinearProgress } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
@@ -12,6 +10,9 @@ import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -1,36 +1,36 @@
 import React, { useEffect, useState } from "react";
+import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
-import { CardHeader, Grid2, LinearProgress } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import Tooltip from "@mui/material/Tooltip";
-import Typography from "@mui/material/Typography";
+import { CardHeader, Grid2, LinearProgress } from "@mui/material";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 
-import { CONTENT_TYPE } from "../AssistantRuleBook";
-import AssistantImageResult from "./AssistantImageResult";
-import AssistantVideoResult from "./AssistantVideoResult";
-import WarningAmber from "./AssistantWarnings";
-import AssistantProcessUrlActions from "./AssistantProcessUrlActions";
-import ImageGridList from "../../../Shared/ImageGridList/ImageGridList";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import {
   setProcessUrl,
   setWarningExpanded,
 } from "../../../../redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import ImageGridList from "../../../Shared/ImageGridList/ImageGridList";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import VideoGridList from "../../../Shared/VideoGridList/VideoGridList";
-
+import { CONTENT_TYPE } from "../AssistantRuleBook";
 import {
   TransHtmlDoubleLinkBreak,
   TransSupportedToolsLink,
 } from "../TransComponents";
-import { Trans } from "react-i18next";
+import AssistantImageResult from "./AssistantImageResult";
+import AssistantProcessUrlActions from "./AssistantProcessUrlActions";
+import AssistantVideoResult from "./AssistantVideoResult";
+import WarningAmber from "./AssistantWarnings";
 
 const AssistantMediaResult = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantProcessUrlActions.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantProcessUrlActions.jsx
@@ -1,10 +1,12 @@
 import React from "react";
+import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
 import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
+import Divider from "@mui/material/Divider";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemAvatar from "@mui/material/ListItemAvatar";
@@ -12,9 +14,6 @@ import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import Divider from "@mui/material/Divider";
-import { KNOWN_LINKS } from "../AssistantRuleBook";
 
 import {
   resetDeepfake as resetDeepfakeImage,
@@ -28,7 +27,8 @@ import {
   resetSyntheticImageDetectionImage,
   setSyntheticImageDetectionUrl,
 } from "../../../../redux/actions/tools/syntheticImageDetectionActions";
-import { Trans } from "react-i18next";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import { KNOWN_LINKS } from "../AssistantRuleBook";
 
 const AssistantProcessUrlActions = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
@@ -1,12 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
-import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import FindInPageIcon from "@mui/icons-material/FindInPage";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import SentimentSatisfied from "@mui/icons-material/SentimentSatisfied";
 import { Chip, Grid2, IconButton } from "@mui/material";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
@@ -14,6 +8,13 @@ import CardMedia from "@mui/material/CardMedia";
 import Collapse from "@mui/material/Collapse";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import FindInPageIcon from "@mui/icons-material/FindInPage";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import SentimentSatisfied from "@mui/icons-material/SentimentSatisfied";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
@@ -19,7 +19,6 @@ import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import Tooltip from "@mui/material/Tooltip";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { Trans } from "react-i18next";
 import {
   TransHtmlDoubleLinkBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
@@ -1,24 +1,25 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import FindInPageIcon from "@mui/icons-material/FindInPage";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import SentimentSatisfied from "@mui/icons-material/SentimentSatisfied";
+import { Chip, Grid2, IconButton } from "@mui/material";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
 import Collapse from "@mui/material/Collapse";
-import FindInPageIcon from "@mui/icons-material/FindInPage";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { Chip, Grid2, IconButton } from "@mui/material";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
-import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
-import SentimentSatisfied from "@mui/icons-material/SentimentSatisfied";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
 import { setAssuranceExpanded } from "../../../../redux/actions/tools/assistantActions";
-import SourceCredibilityResult from "../AssistantCheckResults/SourceCredibilityResult";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import Tooltip from "@mui/material/Tooltip";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import SourceCredibilityResult from "../AssistantCheckResults/SourceCredibilityResult";
 import {
   TransHtmlDoubleLinkBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Chip, Grid2, IconButton } from "@mui/material";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
+import Chip from "@mui/material/Chip";
 import Collapse from "@mui/material/Collapse";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -1,17 +1,15 @@
 import React, { useState } from "react";
 
-import {
-  CardHeader,
-  Checkbox,
-  FormControlLabel,
-  Grid2,
-  List,
-  ListItem,
-  ListItemText,
-} from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Checkbox from "@mui/material/Checkbox";
 import Divider from "@mui/material/Divider";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Grid2 from "@mui/material/Grid2";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import Card from "@mui/material/Card";
+
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import {
   CardHeader,
   Checkbox,
@@ -9,13 +10,18 @@ import {
   ListItem,
   ListItemText,
 } from "@mui/material";
+import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Divider from "@mui/material/Divider";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { v4 as uuidv4 } from "uuid";
+
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import ColourGradientTooltipContent from "./ColourGradientTooltipContent";
+import "./assistantTextResultStyle.css";
 import {
   interpRgb,
   rgbToLuminance,
@@ -23,10 +29,6 @@ import {
   treeMapToElements,
   wrapPlainTextSpan,
 } from "./assistantUtils";
-import ColourGradientTooltipContent from "./ColourGradientTooltipContent";
-import { v4 as uuidv4 } from "uuid";
-
-import "./assistantTextResultStyle.css";
 
 export default function AssistantTextClassification({
   text,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import {
   CardHeader,
   Checkbox,
@@ -15,6 +14,8 @@ import CardContent from "@mui/material/CardContent";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import { v4 as uuidv4 } from "uuid";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -27,7 +27,6 @@ import ColourGradientTooltipContent from "./ColourGradientTooltipContent";
 import { v4 as uuidv4 } from "uuid";
 
 import "./assistantTextResultStyle.css";
-import { Trans } from "react-i18next";
 
 export default function AssistantTextClassification({
   text,
@@ -77,9 +76,6 @@ export default function AssistantTextClassification({
     sentenceThresholdHigh = configs.importanceThresholdHigh;
   }
   // category is confidence for news framing, news genre and subjectivity
-  const categoryTooltipText = keyword("confidence_tooltip_category");
-  const categoryTextLow = keyword("low_confidence");
-  const categoryTextHigh = keyword("high_confidence");
   const categoryRgbLow = configs.confidenceRgbLow;
   const categoryRgbHigh = configs.confidenceRgbHigh;
   const categoryThresholdLow = configs.confidenceThresholdLow;

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from "react";
 import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import { WarningOutlined } from "@mui/icons-material";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { Box, CardHeader, Skeleton, Stack, Tab, Tabs } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
@@ -11,6 +9,9 @@ import Collapse from "@mui/material/Collapse";
 import LinearProgress from "@mui/material/LinearProgress";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import { WarningOutlined } from "@mui/icons-material";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -2,11 +2,16 @@ import React, { useEffect, useState } from "react";
 import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Box, CardHeader, Skeleton, Stack, Tab, Tabs } from "@mui/material";
+import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
 import Collapse from "@mui/material/Collapse";
 import LinearProgress from "@mui/material/LinearProgress";
+import Skeleton from "@mui/material/Skeleton";
+import Stack from "@mui/material/Stack";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -2,15 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import Card from "@mui/material/Card";
-import {
-  Box,
-  CardHeader,
-  Grid2,
-  Tabs,
-  Tab,
-  Skeleton,
-  Stack,
-} from "@mui/material";
+import { Box, CardHeader, Tabs, Tab, Skeleton, Stack } from "@mui/material";
 import CardContent from "@mui/material/CardContent";
 import Collapse from "@mui/material/Collapse";
 
@@ -30,7 +22,6 @@ import AssistantTextSpanClassification from "./AssistantTextSpanClassification";
 import {
   TransCredibilitySignalsLink,
   TransHtmlDoubleLinkBreak,
-  TransHtmlSingleLinkBreak,
   TransSupportedToolsLink,
 } from "../TransComponents";
 import { Trans } from "react-i18next";
@@ -53,9 +44,6 @@ const AssistantTextResult = () => {
   const mtLoading = useSelector((state) => state.assistant.mtLoading);
   const dbkfMatchLoading = useSelector(
     (state) => state.assistant.dbkfTextMatchLoading,
-  );
-  const warningExpanded = useSelector(
-    (state) => state.assistant.warningExpanded,
   );
 
   // news framing (topic)
@@ -110,9 +98,6 @@ const AssistantTextResult = () => {
     (state) => state.assistant.subjectivityFail,
   );
 
-  // checking if user logged in
-  const role = useSelector((state) => state.userSession.user.roles);
-
   // display states
   const textBox = document.getElementById("element-to-check");
   const [expanded, setExpanded] = useState(false);
@@ -121,10 +106,6 @@ const AssistantTextResult = () => {
   const [textTabIndex, setTextTabIndex] = useState(0);
   const handleTabChange = (event, newValue) => {
     setTextTabIndex(newValue);
-  };
-  const handleTabClick = (event) => {
-    // leave unset?
-    //setExpanded(true);
   };
 
   useEffect(() => {
@@ -238,7 +219,6 @@ const AssistantTextResult = () => {
           <Tabs
             value={textTabIndex}
             onChange={handleTabChange}
-            onClick={handleTabClick}
             aria-label="extracted text tabs"
             variant="fullWidth"
           >

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -1,30 +1,30 @@
 import React, { useEffect, useState } from "react";
+import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-
-import Card from "@mui/material/Card";
-import { Box, CardHeader, Tabs, Tab, Skeleton, Stack } from "@mui/material";
-import CardContent from "@mui/material/CardContent";
-import Collapse from "@mui/material/Collapse";
 
 import { WarningOutlined } from "@mui/icons-material";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+import { Box, CardHeader, Skeleton, Stack, Tab, Tabs } from "@mui/material";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Collapse from "@mui/material/Collapse";
 import LinearProgress from "@mui/material/LinearProgress";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import { setWarningExpanded } from "../../../../redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import { treeMapToElements } from "./assistantUtils";
 
-import TextFooter from "./TextFooter.jsx";
-import AssistantTextClassification from "./AssistantTextClassification";
-import AssistantTextSpanClassification from "./AssistantTextSpanClassification";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { setWarningExpanded } from "../../../../redux/actions/tools/assistantActions";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransCredibilitySignalsLink,
   TransHtmlDoubleLinkBreak,
   TransSupportedToolsLink,
 } from "../TransComponents";
-import { Trans } from "react-i18next";
+import AssistantTextClassification from "./AssistantTextClassification";
+import AssistantTextSpanClassification from "./AssistantTextSpanClassification";
+import TextFooter from "./TextFooter.jsx";
+import { treeMapToElements } from "./assistantUtils";
 
 const AssistantTextResult = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import Card from "@mui/material/Card";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import {
   CardHeader,
   Chip,
@@ -9,14 +9,18 @@ import {
   ListItem,
   ListItemText,
 } from "@mui/material";
+import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import Divider from "@mui/material/Divider";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { styled } from "@mui/system";
 
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { v4 as uuidv4 } from "uuid";
+
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import ColourGradientTooltipContent from "./ColourGradientTooltipContent";
 import {
   interpRgb,
   mergeSpanIndices,
@@ -25,9 +29,6 @@ import {
   treeMapToElements,
   wrapPlainTextSpan,
 } from "./assistantUtils";
-import ColourGradientTooltipContent from "./ColourGradientTooltipContent";
-import { styled } from "@mui/system";
-import { v4 as uuidv4 } from "uuid";
 
 // Had to create a custom styled span as the default style attribute does not support
 // :hover metaclass

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -64,9 +64,6 @@ export default function AssistantTextSpanClassification({
   const categoryRgbHigh = configs.confidenceRgbHigh;
 
   const [doHighlightSentence, setDoHighlightSentence] = useState(true);
-  const handleHighlightSentences = (event) => {
-    setDoHighlightSentence(event.target.checked);
-  };
 
   function filterLabelsWithMinThreshold(classification, minThreshold) {
     let filteredLabels = {};

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import {
   CardHeader,
   Chip,
@@ -14,6 +13,9 @@ import CardContent from "@mui/material/CardContent";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
+
 import { styled } from "@mui/system";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -1,16 +1,14 @@
 import React, { useState } from "react";
 
-import {
-  CardHeader,
-  Chip,
-  Grid2,
-  List,
-  ListItem,
-  ListItemText,
-} from "@mui/material";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Chip from "@mui/material/Chip";
 import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
@@ -2,9 +2,6 @@ import React from "react";
 import Iframe from "react-iframe";
 import { useSelector } from "react-redux";
 
-import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
-import FileCopyIcon from "@mui/icons-material/FileCopy";
-import ImageIcon from "@mui/icons-material/Image";
 import { IconButton } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
@@ -12,6 +9,10 @@ import CardMedia from "@mui/material/CardMedia";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
+import FileCopyIcon from "@mui/icons-material/FileCopy";
+import ImageIcon from "@mui/icons-material/Image";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
@@ -1,21 +1,22 @@
 import React from "react";
+import Iframe from "react-iframe";
 import { useSelector } from "react-redux";
 
 import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
-import Card from "@mui/material/Card";
-import CardMedia from "@mui/material/CardMedia";
-import CardActions from "@mui/material/CardActions";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
-import { IconButton } from "@mui/material";
 import ImageIcon from "@mui/icons-material/Image";
-import Iframe from "react-iframe";
+import { IconButton } from "@mui/material";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import CardMedia from "@mui/material/CardMedia";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
-import { KNOWN_LINKS } from "../AssistantRuleBook";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import { KNOWN_LINKS } from "../AssistantRuleBook";
 
 const AssistantVideoResult = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
@@ -2,10 +2,10 @@ import React from "react";
 import Iframe from "react-iframe";
 import { useSelector } from "react-redux";
 
-import { IconButton } from "@mui/material";
 import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
 import CardMedia from "@mui/material/CardMedia";
+import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
@@ -22,9 +22,6 @@ const AssistantVideoResult = () => {
   const classes = useMyStyles();
 
   const processUrl = useSelector((state) => state.assistant.processUrl);
-  const process_url_type = useSelector(
-    (state) => state.assistant.processUrlType,
-  );
   const input_url_type = useSelector((state) => state.assistant.inputUrlType);
 
   const useIframe = () => {

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { WarningAmber } from "@mui/icons-material";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Grid2, IconButton } from "@mui/material";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
 import Collapse from "@mui/material/Collapse";
 import Typography from "@mui/material/Typography";
+
+import { WarningAmber } from "@mui/icons-material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Grid2, IconButton } from "@mui/material";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
 import Collapse from "@mui/material/Collapse";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
 
 import { WarningAmber } from "@mui/icons-material";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
@@ -1,19 +1,21 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import { WarningAmber } from "@mui/icons-material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { Grid2, IconButton } from "@mui/material";
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardMedia from "@mui/material/CardMedia";
 import Collapse from "@mui/material/Collapse";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { Grid2, IconButton } from "@mui/material";
 import Typography from "@mui/material/Typography";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import { setWarningExpanded } from "../../../../redux/actions/tools/assistantActions";
-import DbkfTextResults from "../AssistantCheckResults/DbkfTextResults";
-import DbkfMediaResults from "../AssistantCheckResults/DbkfMediaResults";
 import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import { WarningAmber } from "@mui/icons-material";
+import DbkfMediaResults from "../AssistantCheckResults/DbkfMediaResults";
+import DbkfTextResults from "../AssistantCheckResults/DbkfTextResults";
 
 const AssistantWarnings = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/ColourGradientTooltipContent.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/ColourGradientTooltipContent.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { Grid2 } from "@mui/material";
+import Grid2 from "@mui/material/Grid2";
 import Typography from "@mui/material/Typography";
 
 import { rgbListToGradient } from "./assistantUtils";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/ColourGradientTooltipContent.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/ColourGradientTooltipContent.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Grid2 } from "@mui/material";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 
-import { Grid2, Link } from "@mui/material";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import Link from "@mui/material/Link";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
@@ -3,11 +3,7 @@ import React from "react";
 import Box from "@mui/material/Box";
 import { Grid2, Link } from "@mui/material";
 import Divider from "@mui/material/Divider";
-import {
-  ExpandLessOutlined,
-  ExpandMoreOutlined,
-  UnfoldMore,
-} from "@mui/icons-material";
+import { ExpandLessOutlined, ExpandMoreOutlined } from "@mui/icons-material";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
@@ -130,14 +126,6 @@ export function ExpandMinimise({
 }) {
   return (
     <Tooltip title={expandMinimiseText}>
-      {/* <UnfoldMore
-        className={classes.toolTipIcon}
-        onClick={() => {
-          setExpanded(!expanded);
-        }}
-        sx={{ cursor: "pointer" }}
-        color={"primary"}
-      /> */}
       {displayExpander ? (
         expanded ? (
           <ExpandLessOutlined

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
@@ -1,11 +1,12 @@
 import React from "react";
 
-import { ExpandLessOutlined, ExpandMoreOutlined } from "@mui/icons-material";
 import { Grid2, Link } from "@mui/material";
 import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+
+import { ExpandLessOutlined, ExpandMoreOutlined } from "@mui/icons-material";
 
 import { TextCopy } from "../../../Shared/Utils/TextCopy";
 import { Translate } from "../../../Shared/Utils/Translate";

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
@@ -1,15 +1,15 @@
 import React from "react";
 
-import Box from "@mui/material/Box";
-import { Grid2, Link } from "@mui/material";
-import Divider from "@mui/material/Divider";
 import { ExpandLessOutlined, ExpandMoreOutlined } from "@mui/icons-material";
+import { Grid2, Link } from "@mui/material";
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
-import { getLanguageName } from "../../../Shared/Utils/languageUtils";
 import { TextCopy } from "../../../Shared/Utils/TextCopy";
 import { Translate } from "../../../Shared/Utils/Translate";
+import { getLanguageName } from "../../../Shared/Utils/languageUtils";
 
 export default function TextFooter({
   classes,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 

--- a/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
@@ -3,16 +3,17 @@ import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
-// version 5.2.0
-
-import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { Box, CardHeader, Skeleton, TextField, Tooltip } from "@mui/material/";
 import Button from "@mui/material//Button";
 import Card from "@mui/material//Card";
 import CardContent from "@mui/material//CardContent";
 import Typography from "@mui/material//Typography";
 import Stack from "@mui/material/Stack";
+
+// version 5.2.0
+
+import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 

--- a/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
@@ -1,26 +1,28 @@
 import React, { useState } from "react";
+import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom"; // version 5.2.0
+import { useNavigate } from "react-router-dom";
+
+// version 5.2.0
 
 import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
+import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import { Box, CardHeader, Skeleton, TextField, Tooltip } from "@mui/material/";
 import Button from "@mui/material//Button";
 import Card from "@mui/material//Card";
 import CardContent from "@mui/material//CardContent";
 import Typography from "@mui/material//Typography";
-import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
+import Stack from "@mui/material/Stack";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import { KNOWN_LINKS } from "./AssistantRuleBook";
+import { useTrackEvent } from "../../../Hooks/useAnalytics";
 import {
   cleanAssistantState,
   submitInputUrl,
 } from "../../../redux/actions/tools/assistantActions";
-
-import { useTrackEvent } from "../../../Hooks/useAnalytics";
-import Stack from "@mui/material/Stack";
-import { Trans } from "react-i18next";
+import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
+import { KNOWN_LINKS } from "./AssistantRuleBook";
 import {
   TransHtmlDoubleLinkBreak,
   TransSupportedUrlsLink,

--- a/src/components/NavItems/Assistant/TransComponents.jsx
+++ b/src/components/NavItems/Assistant/TransComponents.jsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Trans } from "react-i18next";
 
 export function TransSupportedToolsLink({ keyword }) {

--- a/src/components/NavItems/ClassRoom/ClassRoom.jsx
+++ b/src/components/NavItems/ClassRoom/ClassRoom.jsx
@@ -1,35 +1,33 @@
 import React, { useState } from "react";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Button,
-  Card,
-  createTheme,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  Divider,
-  Grid2,
-  Tab,
-  Tabs,
-  TextField,
-  ThemeProvider,
-  Typography,
-} from "@mui/material";
+import Iframe from "react-iframe";
+
+import { ThemeProvider, createTheme } from "@mui/material";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 
 import { CastForEducation, ExpandMore } from "@mui/icons-material";
 
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import PropTypes from "prop-types";
 
-import Iframe from "react-iframe";
-import youverifyImage from "./Images/YouVerify_Logo.png";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
+import IconClassRoom from "../../NavBar/images/SVG/Navbar/Classroom.svg";
 import { changeTabEvent } from "../../Shared/GoogleAnalytics/GoogleAnalytics";
 import HeaderTool from "../../Shared/HeaderTool/HeaderTool";
-import IconClassRoom from "../../NavBar/images/SVG/Navbar/Classroom.svg";
+import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
+import youverifyImage from "./Images/YouVerify_Logo.png";
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;

--- a/src/components/NavItems/Interactive/Interactive.jsx
+++ b/src/components/NavItems/Interactive/Interactive.jsx
@@ -1,31 +1,32 @@
 import React, { useState } from "react";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Button,
-  Fab,
-  Grid2,
-  Link,
-  Paper,
-  Typography,
-} from "@mui/material";
-import { useSelector } from "react-redux";
-import CustomTile from "../../Shared/CustomTitle/CustomTitle";
 import Iframe from "react-iframe";
-import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Fab from "@mui/material/Fab";
+import Grid2 from "@mui/material/Grid2";
+import Link from "@mui/material/Link";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
 import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore";
 import NavigateNextIcon from "@mui/icons-material/NavigateNext";
 
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import CustomTile from "../../Shared/CustomTitle/CustomTitle";
 import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
-import { useNavigate } from "react-router-dom";
 import {
-  reverseImageSearch,
   SEARCH_ENGINE_SETTINGS,
+  reverseImageSearch,
 } from "../../Shared/ReverseSearch/reverseSearchUtils";
 
 const Interactive = () => {

--- a/src/components/NavItems/languages/languages.jsx
+++ b/src/components/NavItems/languages/languages.jsx
@@ -1,17 +1,21 @@
 import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
-import { useDispatch, useSelector } from "react-redux";
-import IconButton from "@mui/material/IconButton";
-import { changeLanguage } from "../../../redux/reducers/languageReducer";
-import { changeDefaultLanguage } from "../../../redux/reducers/defaultLanguageReducer";
-import DefaultLanguageDialog from "./defaultLanguageDialog";
-import { setStorageTrue } from "../../../redux/reducers/cookiesReducers";
+import Stack from "@mui/material/Stack";
+
 import TranslateIcon from "@mui/icons-material/Translate";
-import { useTranslation } from "react-i18next";
+
 import useLoadSupportedLanguage from "Hooks/useLoadSupportedLanguages";
-import Box from "@mui/material/Box";
-import { Stack } from "@mui/material";
+
+import { setStorageTrue } from "../../../redux/reducers/cookiesReducers";
+import { changeDefaultLanguage } from "../../../redux/reducers/defaultLanguageReducer";
+import { changeLanguage } from "../../../redux/reducers/languageReducer";
+import DefaultLanguageDialog from "./defaultLanguageDialog";
 
 const Languages = (props) => {
   const { t, i18n } = useTranslation("components/NavItems/languages");

--- a/src/components/NavItems/tools/Alltools/AdvancedTools/AdvancedTools.jsx
+++ b/src/components/NavItems/tools/Alltools/AdvancedTools/AdvancedTools.jsx
@@ -1,26 +1,31 @@
 import React, { useEffect } from "react";
-import { Grid2, Stack } from "@mui/material";
+import { Controller, useForm } from "react-hook-form";
+import { useDispatch, useSelector } from "react-redux";
+
 import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
-import LockIcon from "@mui/icons-material/Lock";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
-import TextField from "@mui/material/TextField";
-import LockOpenIcon from "@mui/icons-material/LockOpen";
-import useAuthenticationAPI from "../../../../Shared/Authentication/useAuthenticationAPI";
-import { useDispatch, useSelector } from "react-redux";
-import { ERR_AUTH_UNKNOWN_ERROR } from "../../../../Shared/Authentication/authenticationErrors";
-import { setError } from "redux/reducers/errorReducer";
+import Grid2 from "@mui/material/Grid2";
 import IconButton from "@mui/material/IconButton";
-import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
-import { Controller, useForm } from "react-hook-form";
-import * as yup from "yup";
-import _ from "lodash";
 import MenuItem from "@mui/material/MenuItem";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+
+import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import LockIcon from "@mui/icons-material/Lock";
+import LockOpenIcon from "@mui/icons-material/LockOpen";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import _ from "lodash";
+import { setError } from "redux/reducers/errorReducer";
+import * as yup from "yup";
+
+import { ERR_AUTH_UNKNOWN_ERROR } from "../../../../Shared/Authentication/authenticationErrors";
+import useAuthenticationAPI from "../../../../Shared/Authentication/useAuthenticationAPI";
 
 const registrationValidationSchema = yup.object().shape({
   email: yup

--- a/src/components/NavItems/tools/Alltools/ToolsMenu.jsx
+++ b/src/components/NavItems/tools/Alltools/ToolsMenu.jsx
@@ -1,41 +1,39 @@
 import React, { useState } from "react";
+import Iframe from "react-iframe";
+import { useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
 
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  Dialog,
-  DialogContent,
-  Grid2,
-  Snackbar,
-  SvgIcon,
-  Tab,
-  Tabs,
-  Typography,
-} from "@mui/material";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import Grid2 from "@mui/material/Grid2";
+import Snackbar from "@mui/material/Snackbar";
+import SvgIcon from "@mui/material/SvgIcon";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import Typography from "@mui/material/Typography";
 
+import { Audiotrack } from "@mui/icons-material";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
 
-import Iframe from "react-iframe";
-import DialogActions from "@mui/material/DialogActions";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import ToolsMenuItem from "./ToolsMenuItem";
-import ImageIcon from "../../../NavBar/images/SVG/Image/Images.svg";
-import VideoIcon from "../../../NavBar/images/SVG/Video/Video.svg";
-import SearchIcon from "../../../NavBar/images/SVG/Search/Search.svg";
-import DataIcon from "../../../NavBar/images/SVG/DataAnalysis/Data_analysis.svg";
-import { useSelector } from "react-redux";
-
-import { useNavigate } from "react-router-dom";
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { Audiotrack } from "@mui/icons-material";
+
+import { ROLES } from "../../../../constants/roles";
 import {
+  TOOLS_CATEGORIES,
   canUserSeeTool,
   tools,
-  TOOLS_CATEGORIES,
 } from "../../../../constants/tools";
-import { ROLES } from "../../../../constants/roles";
+import DataIcon from "../../../NavBar/images/SVG/DataAnalysis/Data_analysis.svg";
+import ImageIcon from "../../../NavBar/images/SVG/Image/Images.svg";
+import SearchIcon from "../../../NavBar/images/SVG/Search/Search.svg";
+import VideoIcon from "../../../NavBar/images/SVG/Video/Video.svg";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import ToolsMenuItem from "./ToolsMenuItem";
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;

--- a/src/components/NavItems/tools/Analysis/Analysis.jsx
+++ b/src/components/NavItems/tools/Analysis/Analysis.jsx
@@ -1,19 +1,25 @@
 import React, { memo, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import TextField from "@mui/material/TextField";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Checkbox from "@mui/material/Checkbox";
-import Button from "@mui/material/Button";
-import LinearProgress from "@mui/material/LinearProgress";
-import Box from "@mui/material/Box";
-import YoutubeResults from "./Results/YoutubeResults";
-import TwitterResults from "./Results/TwitterResults";
-import { useAnalysisWrapper } from "./Hooks/useAnalysisWrapper";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import Iframe from "react-iframe";
-import useGenerateApiUrl from "./Hooks/useGenerateApiUrl";
-import AFacebookResults from "./Results/AFacebookResults";
-import FacebookVideoDescription from "./Results/FacebookVideoDescription";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+import TextField from "@mui/material/TextField";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import _ from "lodash";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { videoAnalysis } from "../../../../constants/tools";
 import {
   cleanAnalysisState,
   setAnalysisComments,
@@ -22,19 +28,16 @@ import {
   setAnalysisResult,
   setAnalysisVerifiedComments,
 } from "../../../../redux/actions/tools/analysisActions";
-import { useParams } from "react-router-dom";
-import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
-import Card from "@mui/material/Card";
-import CardHeader from "@mui/material/CardHeader";
-import { Grid2 } from "@mui/material";
 import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
+import { useAnalysisWrapper } from "./Hooks/useAnalysisWrapper";
+import useGenerateApiUrl from "./Hooks/useGenerateApiUrl";
+import AFacebookResults from "./Results/AFacebookResults";
+import FacebookVideoDescription from "./Results/FacebookVideoDescription";
+import TwitterResults from "./Results/TwitterResults";
+import YoutubeResults from "./Results/YoutubeResults";
 import styles from "./Results/layout.module.css";
-import Alert from "@mui/material/Alert";
-import _ from "lodash";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { videoAnalysis } from "../../../../constants/tools";
 
 const Analysis = () => {
   const caa_analysis_url = process.env.REACT_APP_CAA_ANALYSIS_URL;

--- a/src/components/NavItems/tools/Analysis/Results/AFacebookResults.jsx
+++ b/src/components/NavItems/tools/Analysis/Results/AFacebookResults.jsx
@@ -1,23 +1,28 @@
 import React from "react";
 import { useDispatch } from "react-redux";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import Typography from "@mui/material/Typography";
+
 import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
 import Button from "@mui/material/Button";
-import { Grid2, IconButton } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+
+import CloseIcon from "@mui/icons-material/Close";
+
 import axios from "axios";
-import ImageUrlGridList from "../../../../Shared/ImageGridList/ImageUrlGridList";
-import { submissionEvent } from "../../../../Shared/GoogleAnalytics/GoogleAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import _ from "lodash";
-import AnalysisComments from "./AnalysisComments";
-import { reverseImageSearch } from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+
+import { submissionEvent } from "../../../../Shared/GoogleAnalytics/GoogleAnalytics";
+import ImageUrlGridList from "../../../../Shared/ImageGridList/ImageUrlGridList";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
 import { ReverseSearchButtons } from "../../../../Shared/ReverseSearch/ReverseSearchButtons";
+import { reverseImageSearch } from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+import AnalysisComments from "./AnalysisComments";
 
 const AFacebookResults = (props) => {
   const cleanAnalysisState = props.cleanAnalysisState;

--- a/src/components/NavItems/tools/Analysis/Results/TwitterResults.jsx
+++ b/src/components/NavItems/tools/Analysis/Results/TwitterResults.jsx
@@ -1,20 +1,21 @@
 import React from "react";
 import { useDispatch } from "react-redux";
-import Typography from "@mui/material/Typography";
-import Divider from "@mui/material/Divider";
+
 import Box from "@mui/material/Box";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableRow from "@mui/material/TableRow";
-import TableCell from "@mui/material/TableCell";
 import Button from "@mui/material/Button";
-import { IconButton } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+
+import CloseIcon from "@mui/icons-material/Close";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
 import {
   cleanAnalysisState,
@@ -22,11 +23,12 @@ import {
   setAnalysisLinkComments,
   setAnalysisVerifiedComments,
 } from "../../../../../redux/actions/tools/analysisActions";
-
 import ImageUrlGridList from "../../../../Shared/ImageGridList/ImageUrlGridList";
-import AnalysisComments from "./AnalysisComments";
-import { reverseImageSearch } from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
 import { ReverseSearchButtons } from "../../../../Shared/ReverseSearch/ReverseSearchButtons";
+import { reverseImageSearch } from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+import AnalysisComments from "./AnalysisComments";
 
 const TwitterResults = (props) => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Analysis/Results/YoutubeResults.jsx
+++ b/src/components/NavItems/tools/Analysis/Results/YoutubeResults.jsx
@@ -1,21 +1,23 @@
 import React from "react";
 import { useDispatch } from "react-redux";
-import Typography from "@mui/material/Typography";
-import Divider from "@mui/material/Divider";
+
 import Box from "@mui/material/Box";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableRow from "@mui/material/TableRow";
-import TableCell from "@mui/material/TableCell";
 import Button from "@mui/material/Button";
-import { Grid2, IconButton } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import TimeToLocalTime from "./TimeToLocalTime";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+
+import CloseIcon from "@mui/icons-material/Close";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import {
   cleanAnalysisState,
   setAnalysisComments,
@@ -23,9 +25,12 @@ import {
   setAnalysisVerifiedComments,
 } from "../../../../../redux/actions/tools/analysisActions";
 import ImageUrlGridList from "../../../../Shared/ImageGridList/ImageUrlGridList";
-import AnalysisComments from "./AnalysisComments";
-import { reverseImageSearch } from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
 import { ReverseSearchButtons } from "../../../../Shared/ReverseSearch/ReverseSearchButtons";
+import { reverseImageSearch } from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+import AnalysisComments from "./AnalysisComments";
+import TimeToLocalTime from "./TimeToLocalTime";
 
 const YoutubeResults = (props) => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Analysis_images/Analysis.jsx
+++ b/src/components/NavItems/tools/Analysis_images/Analysis.jsx
@@ -1,27 +1,25 @@
 import React, { memo, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import TextField from "@mui/material/TextField";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import Checkbox from "@mui/material/Checkbox";
-import Button from "@mui/material/Button";
-import LinearProgress from "@mui/material/LinearProgress";
-import Box from "@mui/material/Box";
-import TwitterResults from "./Results/TwitterResults";
-import { useAnalysisWrapper } from "../Analysis/Hooks/useAnalysisWrapper";
-import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
 import Iframe from "react-iframe";
-import useGenerateApiUrl from "../Analysis/Hooks/useGenerateApiUrl";
-import AFacebookResults from "../Analysis/Results/AFacebookResults";
-import FacebookImageDescription from "./Results/FacebookImageDescription";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
-import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { Grid2 } from "@mui/material";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+import TextField from "@mui/material/TextField";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
 import HeaderTool from "@Shared/HeaderTool/HeaderTool";
+import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { imageAnalysis } from "../../../../constants/tools";
 import {
   cleanAnalysisState,
   setAnalysisComments,
@@ -30,7 +28,12 @@ import {
   setAnalysisResult,
   setAnalysisVerifiedComments,
 } from "../../../../redux/actions/tools/image_analysisActions";
-import { imageAnalysis } from "../../../../constants/tools";
+import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
+import { useAnalysisWrapper } from "../Analysis/Hooks/useAnalysisWrapper";
+import useGenerateApiUrl from "../Analysis/Hooks/useGenerateApiUrl";
+import AFacebookResults from "../Analysis/Results/AFacebookResults";
+import FacebookImageDescription from "./Results/FacebookImageDescription";
+import TwitterResults from "./Results/TwitterResults";
 
 const Analysis = () => {
   const caa_analysis_url = process.env.REACT_APP_CAA_ANALYSIS_URL;

--- a/src/components/NavItems/tools/Analysis_images/Results/TwitterResults.jsx
+++ b/src/components/NavItems/tools/Analysis_images/Results/TwitterResults.jsx
@@ -1,25 +1,29 @@
 import React from "react";
 import { useDispatch } from "react-redux";
-import Typography from "@mui/material/Typography";
-import Divider from "@mui/material/Divider";
+
 import Box from "@mui/material/Box";
-import Table from "@mui/material/Table";
-import TableBody from "@mui/material/TableBody";
-import TableRow from "@mui/material/TableRow";
-import TableCell from "@mui/material/TableCell";
-import { IconButton } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import { cleanAnalysisState } from "../../../../../redux/actions/tools/image_analysisActions";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
+import CardMedia from "@mui/material/CardMedia";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import Typography from "@mui/material/Typography";
+
+import CloseIcon from "@mui/icons-material/Close";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { cleanAnalysisState } from "../../../../../redux/actions/tools/image_analysisActions";
 import {
   setAnalysisComments,
   setAnalysisLinkComments,
   setAnalysisVerifiedComments,
 } from "../../../../../redux/actions/tools/image_analysisActions";
-import CardMedia from "@mui/material/CardMedia";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
 import AnalysisComments from "../../Analysis/Results/AnalysisComments";
 
 const TwitterResults = (props) => {

--- a/src/components/NavItems/tools/Archive/components/FifthStep.jsx
+++ b/src/components/NavItems/tools/Archive/components/FifthStep.jsx
@@ -1,12 +1,19 @@
 import React from "react";
-import { Alert, Box, Fade, Skeleton, Stack } from "@mui/material";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
-import ArchivedFileCard from "./archivedFileCard";
-import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
+import Fade from "@mui/material/Fade";
+import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
-import List from "@mui/material/List";
+import Skeleton from "@mui/material/Skeleton";
+import Stack from "@mui/material/Stack";
+
+import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
+
 import { prettifyLargeString } from "../utils";
+import ArchivedFileCard from "./archivedFileCard";
 
 const FifthStep = ({
   archiveFileToWbm,

--- a/src/components/NavItems/tools/Archive/components/FirstStep.jsx
+++ b/src/components/NavItems/tools/Archive/components/FirstStep.jsx
@@ -1,18 +1,19 @@
 import React, { useEffect } from "react";
-import {
-  Box,
-  Divider,
-  List,
-  ListItemButton,
-  ListItemText,
-  Stack,
-  TextField,
-  Typography,
-} from "@mui/material";
+
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemText from "@mui/material/ListItemText";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+
 import { ArrowForward } from "@mui/icons-material";
-import { isValidUrl } from "@Shared/Utils/URLUtils";
+
 import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
+import { isValidUrl } from "@Shared/Utils/URLUtils";
 
 const FirstStep = ({ handleClick, url, handleUrlChange }) => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Archive");

--- a/src/components/NavItems/tools/Archive/components/FourthStep.jsx
+++ b/src/components/NavItems/tools/Archive/components/FourthStep.jsx
@@ -1,7 +1,14 @@
 import React from "react";
-import { Box, Button, ButtonGroup, Stack, Typography } from "@mui/material";
-import FolderOpenIcon from "@mui/icons-material/FolderOpen";
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import CloseIcon from "@mui/icons-material/Close";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
+
 import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
 
 const FourthStep = ({ fileInput, setFileInput }) => {

--- a/src/components/NavItems/tools/Archive/components/SecondStep.jsx
+++ b/src/components/NavItems/tools/Archive/components/SecondStep.jsx
@@ -1,15 +1,16 @@
 import React from "react";
-import {
-  Box,
-  Divider,
-  Link,
-  ListItemText,
-  Stack,
-  Typography,
-} from "@mui/material";
+
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
+import Link from "@mui/material/Link";
 import ListItem from "@mui/material/ListItem";
-import DownloadWaczFile from "./downloadWaczFile";
+import ListItemText from "@mui/material/ListItemText";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
+
+import DownloadWaczFile from "./downloadWaczFile";
 
 const SecondStep = ({ url }) => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Archive");

--- a/src/components/NavItems/tools/Archive/components/StyledMenu.jsx
+++ b/src/components/NavItems/tools/Archive/components/StyledMenu.jsx
@@ -1,10 +1,13 @@
 import * as React from "react";
-import { alpha, styled } from "@mui/material/styles";
+
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
-import Divider from "@mui/material/Divider";
-import { IconButton } from "@mui/material";
+import { alpha, styled } from "@mui/material/styles";
+
 import { Archive, FileUpload, MoreVert, Replay } from "@mui/icons-material";
+
 import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
 
 const StyledMenu = styled((props) => (

--- a/src/components/NavItems/tools/Archive/components/ThirdStep.jsx
+++ b/src/components/NavItems/tools/Archive/components/ThirdStep.jsx
@@ -1,16 +1,16 @@
 import React from "react";
-import {
-  Box,
-  Divider,
-  FormHelperText,
-  Link,
-  Stack,
-  Typography,
-} from "@mui/material";
-import Radio from "@mui/material/Radio";
-import FormControlLabel from "@mui/material/FormControlLabel";
-import RadioGroup from "@mui/material/RadioGroup";
+
+import Box from "@mui/material/Box";
+import Divider from "@mui/material/Divider";
 import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormHelperText from "@mui/material/FormHelperText";
+import Link from "@mui/material/Link";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
 
 const ThirdStep = ({

--- a/src/components/NavItems/tools/Archive/components/archiveTable.jsx
+++ b/src/components/NavItems/tools/Archive/components/archiveTable.jsx
@@ -1,25 +1,25 @@
 import React, { useState } from "react";
+import { useSelector } from "react-redux";
 
-import {
-  IconButton,
-  Link,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Tooltip,
-} from "@mui/material";
+import IconButton from "@mui/material/IconButton";
+import Link from "@mui/material/Link";
+import Paper from "@mui/material/Paper";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableContainer from "@mui/material/TableContainer";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import Tooltip from "@mui/material/Tooltip";
 
-import FileCopyIcon from "@mui/icons-material/FileCopy";
 import DoneIcon from "@mui/icons-material/Done";
-import { prettifyLargeString } from "../utils";
+import FileCopyIcon from "@mui/icons-material/FileCopy";
+
 import { useTrackEvent } from "Hooks/useAnalytics";
 import { getclientId } from "components/Shared/GoogleAnalytics/MatomoAnalytics";
-import { useSelector } from "react-redux";
+
 import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
+import { prettifyLargeString } from "../utils";
 
 export const ArchiveTable = (props) => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Archive");

--- a/src/components/NavItems/tools/Archive/components/archivedFileCard.jsx
+++ b/src/components/NavItems/tools/Archive/components/archivedFileCard.jsx
@@ -1,7 +1,13 @@
 import React from "react";
-import { Alert, Box, Card, Fade, Stack } from "@mui/material";
-import ArchiveTable from "./archiveTable";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import Fade from "@mui/material/Fade";
+import Stack from "@mui/material/Stack";
+
 import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
+import ArchiveTable from "./archiveTable";
 
 const ArchivedFileCard = ({ file, archiveLinks }) => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Archive");

--- a/src/components/NavItems/tools/Archive/components/downloadWaczFile.jsx
+++ b/src/components/NavItems/tools/Archive/components/downloadWaczFile.jsx
@@ -1,10 +1,16 @@
-import React from "react";
-import { Box, Stack, Typography } from "@mui/material";
 import { useMutation } from "@tanstack/react-query";
-import useAuthenticatedRequest from "../../../../Shared/Authentication/useAuthenticatedRequest";
-import LoadingButton from "@mui/lab/LoadingButton";
+import React from "react";
+
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import { Download } from "@mui/icons-material";
+
 import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
+import LoadingButton from "@mui/lab/LoadingButton";
+
+import useAuthenticatedRequest from "../../../../Shared/Authentication/useAuthenticatedRequest";
 
 /**
  *

--- a/src/components/NavItems/tools/Archive/components/urlArchive.jsx
+++ b/src/components/NavItems/tools/Archive/components/urlArchive.jsx
@@ -1,24 +1,25 @@
-import {
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Link,
-  Stack,
-  Typography,
-} from "@mui/material";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import React, { useEffect, useState } from "react";
-import IconInternetArchive from "../../../../NavBar/images/SVG/Others/archive-icon.svg";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
 import { useSelector } from "react-redux";
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
 import { history } from "@Shared/History/History";
-import { prettifyLargeString } from "../utils";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { useTrackEvent } from "../../../../../Hooks/useAnalytics";
+import { ROLES } from "../../../../../constants/roles";
+import IconInternetArchive from "../../../../NavBar/images/SVG/Others/archive-icon.svg";
 import CopyButton from "../../../../Shared/CopyButton";
 import { KNOWN_LINKS } from "../../../Assistant/AssistantRuleBook";
+import { prettifyLargeString } from "../utils";
 import DownloadWaczFile from "./downloadWaczFile";
-import { ROLES } from "../../../../../constants/roles";
-import { useTrackEvent } from "../../../../../Hooks/useAnalytics";
 
 /**
  *

--- a/src/components/NavItems/tools/Archive/index.jsx
+++ b/src/components/NavItems/tools/Archive/index.jsx
@@ -1,30 +1,38 @@
+import { QueryClient, useMutation } from "@tanstack/react-query";
 import React, { useEffect, useState } from "react";
-
-import { Box, Button, Card, Grid2, Stack, Typography } from "@mui/material";
-import useAuthenticatedRequest from "../../../Shared/Authentication/useAuthenticatedRequest";
+import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import Grid2 from "@mui/material/Grid2";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
+import { ArrowBack } from "@mui/icons-material";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import {
   archiveStateCleaned,
   setArchiveUrl,
 } from "redux/reducers/tools/archiveReducer";
-import { useDispatch, useSelector } from "react-redux";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import { archiving } from "../../../../constants/tools";
+import useAuthenticatedRequest from "../../../Shared/Authentication/useAuthenticatedRequest";
+import assistantApiCalls from "../../Assistant/AssistantApiHandlers/useAssistantApi";
 import {
-  KNOWN_LINK_PATTERNS,
   KNOWN_LINKS,
+  KNOWN_LINK_PATTERNS,
   matchPattern,
 } from "../../Assistant/AssistantRuleBook";
-import assistantApiCalls from "../../Assistant/AssistantApiHandlers/useAssistantApi";
-import { QueryClient, useMutation } from "@tanstack/react-query";
-import CustomizedMenus, { StyledMenu } from "./components/StyledMenu";
-import FirstStep from "./components/FirstStep";
-import SecondStep from "./components/SecondStep";
-import { ArrowBack } from "@mui/icons-material";
-import ThirdStep from "./components/ThirdStep";
-import FourthStep from "./components/FourthStep";
 import FifthStep from "./components/FifthStep";
+import FirstStep from "./components/FirstStep";
+import FourthStep from "./components/FourthStep";
+import SecondStep from "./components/SecondStep";
 import SixthStep from "./components/SixthStep";
+import CustomizedMenus, { StyledMenu } from "./components/StyledMenu";
+import ThirdStep from "./components/ThirdStep";
 
 const queryClient = new QueryClient();
 

--- a/src/components/NavItems/tools/C2pa/C2pa.jsx
+++ b/src/components/NavItems/tools/C2pa/C2pa.jsx
@@ -1,22 +1,27 @@
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Alert,
-  Box,
-  Card,
-  FormControlLabel,
-  FormGroup,
-  LinearProgress,
-  Stack,
-  Switch,
-} from "@mui/material";
-import HeaderTool from "components/Shared/HeaderTool/HeaderTool";
-import useMyStyles from "components/Shared/MaterialUiStyles/useMyStyles";
-import StringFileUploadField from "components/Shared/StringFileUploadField";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import C2paResults from "./Results/C2paResults";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CircularProgress from "@mui/material/CircularProgress";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import LinearProgress from "@mui/material/LinearProgress";
+import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
+import Typography from "@mui/material/Typography";
+
+import { ArrowDownward } from "@mui/icons-material";
+
+import HeaderTool from "components/Shared/HeaderTool/HeaderTool";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "components/Shared/MaterialUiStyles/useMyStyles";
+import StringFileUploadField from "components/Shared/StringFileUploadField";
+import exifr from "exifr";
 import {
   c2paLoadingSet,
   resetC2paState,
@@ -25,15 +30,12 @@ import {
   setC2paThumbnailCaption,
   setHdImageC2paData,
 } from "redux/reducers/tools/c2paReducer";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useAuthenticatedRequest from "../../../Shared/Authentication/useAuthenticatedRequest";
-import CircularProgress from "@mui/material/CircularProgress";
-import getC2paData, { getC2paDataHd } from "./Hooks/useGetC2paData";
-import exifr from "exifr";
-import { ArrowDownward } from "@mui/icons-material";
-import Typography from "@mui/material/Typography";
 import { v4 as uuidv4 } from "uuid";
+
 import { ROLES } from "../../../../constants/roles";
+import useAuthenticatedRequest from "../../../Shared/Authentication/useAuthenticatedRequest";
+import getC2paData, { getC2paDataHd } from "./Hooks/useGetC2paData";
+import C2paResults from "./Results/C2paResults";
 import AfpReverseSearchResults from "./components/AfpReverseSearchResults";
 import HdImageResults from "./components/HdImageResults";
 

--- a/src/components/NavItems/tools/C2pa/Results/C2paResults.jsx
+++ b/src/components/NavItems/tools/C2pa/Results/C2paResults.jsx
@@ -1,33 +1,33 @@
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Divider,
-  Grid2,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { useEffect, useState } from "react";
+import { MapContainer, Marker, TileLayer } from "react-leaflet";
+import { useDispatch, useSelector } from "react-redux";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 
 import {
   ExpandMore,
   KeyboardArrowLeft,
   KeyboardDoubleArrowLeft,
 } from "@mui/icons-material";
-import { useDispatch, useSelector } from "react-redux";
-import { c2paCurrentImageIdSet } from "redux/reducers/tools/c2paReducer";
-import moment from "moment";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { MapContainer, Marker, TileLayer } from "react-leaflet";
-import { Icon as GeoIcon } from "leaflet";
-import { useEffect, useState } from "react";
-import MapIcon from "@mui/icons-material/Map";
 import HelpIcon from "@mui/icons-material/Help";
+import MapIcon from "@mui/icons-material/Map";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { Icon as GeoIcon } from "leaflet";
+import moment from "moment";
+import { c2paCurrentImageIdSet } from "redux/reducers/tools/c2paReducer";
 
 /**
  *
@@ -108,6 +108,7 @@ const C2paResults = ({ result, hasSimilarAfpResult }) => {
   };
 
   return (
+    // </Card>
     <Grid2 container direction="row" spacing={3} p={4}>
       <Grid2 container justifyContent="start" size={{ md: 12, lg: 6 }}>
         <Grid2>
@@ -480,7 +481,6 @@ const C2paResults = ({ result, hasSimilarAfpResult }) => {
         </Card>
       </Grid2>
     </Grid2>
-    // </Card>
   );
 };
 

--- a/src/components/NavItems/tools/C2pa/components/AfpReverseSearchResults.jsx
+++ b/src/components/NavItems/tools/C2pa/components/AfpReverseSearchResults.jsx
@@ -1,11 +1,19 @@
 import React, { useState } from "react";
-import { Alert, Box, Grid2, List, ListItemText, Stack } from "@mui/material";
-import Typography from "@mui/material/Typography";
 import { useSelector } from "react-redux";
-import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
-import { TabContext, TabList, TabPanel } from "@mui/lab";
-import Tab from "@mui/material/Tab";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Grid2 from "@mui/material/Grid2";
+import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import Stack from "@mui/material/Stack";
+import Tab from "@mui/material/Tab";
+import Typography from "@mui/material/Typography";
+
+import { TabContext, TabList, TabPanel } from "@mui/lab";
+
+import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
 import { prettyCase } from "../../../../Shared/Utils/stringUtils";
 
 const AfpReverseSearchResults = ({

--- a/src/components/NavItems/tools/C2pa/components/HdImageResults.jsx
+++ b/src/components/NavItems/tools/C2pa/components/HdImageResults.jsx
@@ -1,23 +1,24 @@
 import React, { useEffect, useRef, useState } from "react";
-import {
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardActionArea,
-  CardContent,
-  Divider,
-  Grid2,
-  Stack,
-  Typography,
-} from "@mui/material";
 import { useSelector } from "react-redux";
-import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
-import { ROLES } from "../../../../../constants/roles";
-import C2paCard from "./c2paCard";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardActionArea from "@mui/material/CardActionArea";
+import CardContent from "@mui/material/CardContent";
 import CardMedia from "@mui/material/CardMedia";
-import { getBlob } from "../../../../Shared/ReverseSearch/utils/searchUtils";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import { deepClone } from "@mui/x-data-grid/internals";
+
+import { ROLES } from "../../../../../constants/roles";
+import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
+import { getBlob } from "../../../../Shared/ReverseSearch/utils/searchUtils";
+import C2paCard from "./c2paCard";
 
 const HdImageResults = ({ downloadHdImage, hdImage, hdImageC2paData }) => {
   const role = useSelector((state) => state.userSession.user.roles);

--- a/src/components/NavItems/tools/C2pa/components/c2paCard.jsx
+++ b/src/components/NavItems/tools/C2pa/components/c2paCard.jsx
@@ -1,29 +1,31 @@
 import React, { useEffect, useState } from "react";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Alert,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  Divider,
-  Grid2,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import moment from "moment/moment";
 import { MapContainer, Marker, TileLayer } from "react-leaflet";
-import MapIcon from "@mui/icons-material/Map";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+
 import {
   ExpandMore,
   KeyboardArrowLeft,
   KeyboardDoubleArrowLeft,
 } from "@mui/icons-material";
-import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
 import HelpIcon from "@mui/icons-material/Help";
+import MapIcon from "@mui/icons-material/Map";
+
+import moment from "moment/moment";
+
+import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
 
 const C2PaCard = ({ c2paData, currentImageSrc, setCurrentImageSrc }) => {
   const [mainImageId, setMainImageId] = useState(c2paData.mainImageId);

--- a/src/components/NavItems/tools/Deepfake/DeepfakeImage.jsx
+++ b/src/components/NavItems/tools/Deepfake/DeepfakeImage.jsx
@@ -1,22 +1,24 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import LinearProgress from "@mui/material/LinearProgress";
-import Box from "@mui/material/Box";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { Grid2 } from "@mui/material";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+
+import { preprocessFileUpload } from "@Shared/Utils/fileUtils";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { setError } from "redux/reducers/errorReducer";
+
+import { imageDeepfake } from "../../../../constants/tools";
+import { resetDeepfake } from "../../../../redux/actions/tools/deepfakeImageActions";
 import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import StringFileUploadField from "../../../Shared/StringFileUploadField";
 import UseGetDeepfake from "./Hooks/useGetDeepfake";
 import DeepfakeResultsImage from "./Results/DeepfakeResultsImage";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import Alert from "@mui/material/Alert";
-import { setError } from "redux/reducers/errorReducer";
-import StringFileUploadField from "../../../Shared/StringFileUploadField";
-import { resetDeepfake } from "../../../../redux/actions/tools/deepfakeImageActions";
-import { preprocessFileUpload } from "@Shared/Utils/fileUtils";
-import { imageDeepfake } from "../../../../constants/tools";
 
 const Deepfake = () => {
   //const { url } = useParams();

--- a/src/components/NavItems/tools/Deepfake/DeepfakeVideo.jsx
+++ b/src/components/NavItems/tools/Deepfake/DeepfakeVideo.jsx
@@ -1,21 +1,24 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import LinearProgress from "@mui/material/LinearProgress";
+
+import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { Grid2 } from "@mui/material";
-import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
-import UseGetDeepfake from "./Hooks/useGetDeepfake";
-import DeepfakeResultsVideo from "./Results/DeepfakeResultsVideo";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import Alert from "@mui/material/Alert";
-import { resetDeepfake } from "../../../../redux/actions/tools/deepfakeVideoActions";
+import StringFileUploadField from "components/Shared/StringFileUploadField";
 import { preprocessFileUpload } from "components/Shared/Utils/fileUtils";
 import { setError } from "redux/reducers/errorReducer";
-import StringFileUploadField from "components/Shared/StringFileUploadField";
+
 import { videoDeepfake } from "../../../../constants/tools";
+import { resetDeepfake } from "../../../../redux/actions/tools/deepfakeVideoActions";
+import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import UseGetDeepfake from "./Hooks/useGetDeepfake";
+import DeepfakeResultsVideo from "./Results/DeepfakeResultsVideo";
 
 const Deepfake = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Deepfake/Results/DeepfakeResultsImage.jsx
+++ b/src/components/NavItems/tools/Deepfake/Results/DeepfakeResultsImage.jsx
@@ -1,15 +1,22 @@
 import React, { useEffect, useRef, useState } from "react";
+import { useSelector } from "react-redux";
+
 import Box from "@mui/material/Box";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { Grid2, IconButton, Stack, Typography } from "@mui/material";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import { Close } from "@mui/icons-material";
-import { useSelector } from "react-redux";
-import { getclientId } from "components/Shared/GoogleAnalytics/MatomoAnalytics";
+
 import { useTrackEvent } from "Hooks/useAnalytics";
 import GaugeChartResult from "components/Shared/GaugeChartResults/GaugeChartResult";
+import { getclientId } from "components/Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
 
 const DeepfakeResultsImage = (props) => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Deepfake/Results/DeepfakeResultsVideo.jsx
+++ b/src/components/NavItems/tools/Deepfake/Results/DeepfakeResultsVideo.jsx
@@ -1,22 +1,23 @@
 import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+
 import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
-import {
-  CardContent,
-  Grid2,
-  IconButton,
-  Popover,
-  Stack,
-  Typography,
-} from "@mui/material";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import CloseIcon from "@mui/icons-material/Close";
-import { getclientId } from "components/Shared/GoogleAnalytics/MatomoAnalytics";
-import { useSelector } from "react-redux";
-import { useTrackEvent } from "Hooks/useAnalytics";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import Popover from "@mui/material/Popover";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import { Close } from "@mui/icons-material";
+import CloseIcon from "@mui/icons-material/Close";
+
+import { useTrackEvent } from "Hooks/useAnalytics";
 import GaugeChartResult from "components/Shared/GaugeChartResults/GaugeChartResult";
+import { getclientId } from "components/Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
 const DeepfakeResultsVideo = (props) => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Deepfake");

--- a/src/components/NavItems/tools/Forensic/Forensic.jsx
+++ b/src/components/NavItems/tools/Forensic/Forensic.jsx
@@ -1,26 +1,29 @@
 import React, { useEffect, useState } from "react";
-import Box from "@mui/material/Box";
 import { useDispatch, useSelector } from "react-redux";
-import useGetImages from "./Hooks/useGetImages";
-import LinearProgress from "@mui/material/LinearProgress";
-import ForensicResults from "./Results/ForensicResult";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import { useParams } from "react-router-dom";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
-import Alert from "@mui/material/Alert";
-import { resetForensicState } from "../../../../redux/actions/tools/forensicActions";
-import { setError } from "redux/reducers/errorReducer";
-import axios from "axios";
+import LinearProgress from "@mui/material/LinearProgress";
+import Stack from "@mui/material/Stack";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
 import { preprocessFileUpload } from "@Shared/Utils/fileUtils";
-import StringFileUploadField from "../../../Shared/StringFileUploadField";
-import { Stack } from "@mui/material";
+import axios from "axios";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { setError } from "redux/reducers/errorReducer";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
 import { imageForensic } from "../../../../constants/tools";
+import { resetForensicState } from "../../../../redux/actions/tools/forensicActions";
+import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import StringFileUploadField from "../../../Shared/StringFileUploadField";
+import useGetImages from "./Hooks/useGetImages";
+import ForensicResults from "./Results/ForensicResult";
 
 const Forensic = () => {
   const { url } = useParams();

--- a/src/components/NavItems/tools/Forensic/Results/ForensicResult.jsx
+++ b/src/components/NavItems/tools/Forensic/Results/ForensicResult.jsx
@@ -1,43 +1,48 @@
-import Box from "@mui/material/Box";
-import { Button, Grid2 } from "@mui/material";
 import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import Typography from "@mui/material/Typography";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import Tabs from "@mui/material/Tabs";
-import Tab from "@mui/material/Tab";
+import CardMedia from "@mui/material/CardMedia";
 import Divider from "@mui/material/Divider";
-import InfoIcon from "@mui/icons-material/Info";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import CancelIcon from "@mui/icons-material/Cancel";
-import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
-import Popover from "@mui/material/Popover";
-import CloseIcon from "@mui/icons-material/Close";
-import GifIcon from "@mui/icons-material/Gif";
 import Fab from "@mui/material/Fab";
-import NavigateNextIcon from "@mui/icons-material/NavigateNext";
+import Fade from "@mui/material/Fade";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import Popover from "@mui/material/Popover";
+import Snackbar from "@mui/material/Snackbar";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import Typography from "@mui/material/Typography";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import CancelIcon from "@mui/icons-material/Cancel";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import CloseIcon from "@mui/icons-material/Close";
+import EmojiObjectsIcon from "@mui/icons-material/EmojiObjects";
+import GifIcon from "@mui/icons-material/Gif";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import InfoIcon from "@mui/icons-material/Info";
+import LinkIcon from "@mui/icons-material/Link";
 import NavigateBeforeIcon from "@mui/icons-material/NavigateBefore";
+import NavigateNextIcon from "@mui/icons-material/NavigateNext";
+import WarningIcon from "@mui/icons-material/Warning";
+
+import { DetectionProgressBar } from "components/Shared/DetectionProgressBar/DetectionProgressBar";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { ROLES } from "../../../../../constants/roles";
 import { setForensicImageRatio } from "../../../../../redux/actions/tools/forensicActions";
 import {
   setStateBackResults,
   setStateInit,
 } from "../../../../../redux/reducers/tools/gifReducer";
-import LinkIcon from "@mui/icons-material/Link";
-import IconButton from "@mui/material/IconButton";
-import Snackbar from "@mui/material/Snackbar";
-import WarningIcon from "@mui/icons-material/Warning";
-import Alert from "@mui/material/Alert";
-import EmojiObjectsIcon from "@mui/icons-material/EmojiObjects";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
 import AnimatedGif from "../../Gif/AnimatedGif";
-import { DetectionProgressBar } from "components/Shared/DetectionProgressBar/DetectionProgressBar";
 import ImageCanvas from "../components/imageCanvas/imageCanvas";
-import Fade from "@mui/material/Fade";
-import CardMedia from "@mui/material/CardMedia";
-import { ROLES } from "../../../../../constants/roles";
 
 function TabPanel(props) {
   const { children, value, index, ...other } = props;

--- a/src/components/NavItems/tools/Geolocation/Geolocation.jsx
+++ b/src/components/NavItems/tools/Geolocation/Geolocation.jsx
@@ -1,21 +1,23 @@
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import TextField from "@mui/material/TextField";
-import Button from "@mui/material/Button";
-import LinearProgress from "@mui/material/LinearProgress";
-import Box from "@mui/material/Box";
-import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
 
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { Grid2 } from "@mui/material";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+import TextField from "@mui/material/TextField";
+
+import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { imageGeolocation } from "../../../../constants/tools";
+import { resetGeolocation } from "../../../../redux/reducers/tools/geolocationReducer";
 import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
 import useGeolocate from "./Hooks/useGeolocate";
 import GeolocationResults from "./Results/GeolocationResults";
-import Alert from "@mui/material/Alert";
-import { resetGeolocation } from "../../../../redux/reducers/tools/geolocationReducer";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { imageGeolocation } from "../../../../constants/tools";
 
 const Geolocation = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Geolocation/Results/GeolocationResults.jsx
+++ b/src/components/NavItems/tools/Geolocation/Results/GeolocationResults.jsx
@@ -1,14 +1,19 @@
 import React, { useEffect, useState } from "react";
-import Button from "@mui/material/Button";
+import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
+
 import Box from "@mui/material/Box";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { CardMedia, Grid2, Typography } from "@mui/material";
-import { MapContainer, Marker, Popup, TileLayer } from "react-leaflet";
-import "leaflet/dist/leaflet.css";
-import { Icon } from "leaflet";
+import CardMedia from "@mui/material/CardMedia";
+import Grid2 from "@mui/material/Grid2";
+import Typography from "@mui/material/Typography";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { Icon } from "leaflet";
+import "leaflet/dist/leaflet.css";
+
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
 
 const GeolocationResults = (props) => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Gif/AnimatedGif.jsx
+++ b/src/components/NavItems/tools/Gif/AnimatedGif.jsx
@@ -1,11 +1,20 @@
 import React, { useEffect, useState } from "react";
-import useGetGif from "./Hooks/useGetGif";
-import { Alert, Box, Button, Grid2, Slider, Typography } from "@mui/material";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Grid2 from "@mui/material/Grid2";
+import Slider from "@mui/material/Slider";
+import Typography from "@mui/material/Typography";
+
+import { Edit, PlayArrow } from "@mui/icons-material";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import ImageCanvas from "../Forensic/components/imageCanvas/imageCanvas";
 import TextImageCanvas from "./Components/TextImageCanvas";
-import { Edit, PlayArrow } from "@mui/icons-material";
+import useGetGif from "./Hooks/useGetGif";
 
 const AnimatedGif = ({
   toolState,

--- a/src/components/NavItems/tools/Gif/CheckGif.jsx
+++ b/src/components/NavItems/tools/Gif/CheckGif.jsx
@@ -1,19 +1,25 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+
 import Box from "@mui/material/Box";
-import useGetHomographics from "./Hooks/useGetHomographics";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import Typography from "@mui/material/Typography";
-import { Grid2 } from "@mui/material";
-import Button from "@mui/material/Button";
-import DragAndDrop from "./DragAndDrop";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import LinkIcon from "@mui/icons-material/Link";
-import FileIcon from "@mui/icons-material/InsertDriveFile";
-import TextField from "@mui/material/TextField";
 import CircularProgress from "@mui/material/CircularProgress";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import FileIcon from "@mui/icons-material/InsertDriveFile";
+import LinkIcon from "@mui/icons-material/Link";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { imageGif } from "../../../../constants/tools";
 import {
   setStateInit,
   setStateReady,
@@ -21,12 +27,10 @@ import {
   setStateSelectingUrl,
 } from "../../../../redux/reducers/tools/gifReducer";
 import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
-import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import IconButton from "@mui/material/IconButton";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import AnimatedGif from "./AnimatedGif";
-import { imageGif } from "../../../../constants/tools";
+import DragAndDrop from "./DragAndDrop";
+import useGetHomographics from "./Hooks/useGetHomographics";
 
 const CheckGif = () => {
   //Init variables

--- a/src/components/NavItems/tools/Gif/Components/TextImageCanvas.jsx
+++ b/src/components/NavItems/tools/Gif/Components/TextImageCanvas.jsx
@@ -1,19 +1,20 @@
 import React, { useEffect, useState } from "react";
 import { Image, Layer, Stage, Text } from "react-konva";
-import { preloadImage } from "../../Forensic/utils";
-import {
-  Alert,
-  Box,
-  FormControl,
-  Grid2,
-  InputLabel,
-  MenuItem,
-  Select,
-  Slider,
-  Typography,
-} from "@mui/material";
-import useMyStyles from "components/Shared/MaterialUiStyles/useMyStyles";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import FormControl from "@mui/material/FormControl";
+import Grid2 from "@mui/material/Grid2";
+import InputLabel from "@mui/material/InputLabel";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import Slider from "@mui/material/Slider";
+import Typography from "@mui/material/Typography";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "components/Shared/MaterialUiStyles/useMyStyles";
+
+import { preloadImage } from "../../Forensic/utils";
 
 const TextImageCanvas = ({
   imgSrc,

--- a/src/components/NavItems/tools/Gif/DragAndDrop.jsx
+++ b/src/components/NavItems/tools/Gif/DragAndDrop.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
-import { Grid2 } from "@mui/material";
+
+import Grid2 from "@mui/material/Grid2";
 
 class DragAndDrop extends Component {
   state = {

--- a/src/components/NavItems/tools/Keyframes/Keyframes.jsx
+++ b/src/components/NavItems/tools/Keyframes/Keyframes.jsx
@@ -1,29 +1,32 @@
 import React, { memo, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import Box from "@mui/material/Box";
-import TextField from "@mui/material/TextField";
-import Button from "@mui/material/Button";
-import LocalFile from "./LocalFile/LocalFile";
-import LinearProgress from "@mui/material/LinearProgress";
-import Typography from "@mui/material/Typography";
-import Divider from "@mui/material/Divider";
-import KeyFramesResults from "./Results/KeyFramesResults";
-import { useKeyframeWrapper } from "./Hooks/useKeyframeWrapper";
-import { useVideoSimilarity } from "./Hooks/useVideoSimilarity";
-import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
 import { useParams } from "react-router-dom";
-import "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
 
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { Grid2 } from "@mui/material";
-import HeaderTool from "@Shared/HeaderTool/HeaderTool";
-import LinkIcon from "@mui/icons-material/Link";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+
 import FileIcon from "@mui/icons-material/InsertDriveFile";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import LinkIcon from "@mui/icons-material/Link";
+
+import "@Shared/GoogleAnalytics/MatomoAnalytics";
+import HeaderTool from "@Shared/HeaderTool/HeaderTool";
 import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
 import { keyframes } from "../../../../constants/tools";
+import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
+import { useKeyframeWrapper } from "./Hooks/useKeyframeWrapper";
+import { useVideoSimilarity } from "./Hooks/useVideoSimilarity";
+import LocalFile from "./LocalFile/LocalFile";
+import KeyFramesResults from "./Results/KeyFramesResults";
 
 const Keyframes = () => {
   const { url } = useParams();

--- a/src/components/NavItems/tools/Keyframes/Results/KeyFramesResults.jsx
+++ b/src/components/NavItems/tools/Keyframes/Results/KeyFramesResults.jsx
@@ -1,41 +1,41 @@
 import React, { memo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import ImageGridList from "../../../../Shared/ImageGridList/ImageGridList";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
 import Box from "@mui/material/Box";
-import Divider from "@mui/material/Divider";
 import Button from "@mui/material/Button";
-import { useKeyframes } from "../Hooks/usekeyframes";
-//import { useLoading, loadImageSize } from "../../../../../Hooks/useInput"
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  CircularProgress,
-  Grid2,
-  IconButton,
-  Typography,
-} from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import { cleanKeyframesState } from "../../../../../redux/actions/tools/keyframesActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
+import CircularProgress from "@mui/material/CircularProgress";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
 import Link from "@mui/material/Link";
-
-import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import Popover from "@mui/material/Popover";
-import ZoomInIcon from "@mui/icons-material/ZoomIn";
-import ZoomOutIcon from "@mui/icons-material/ZoomOut";
+import Typography from "@mui/material/Typography";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import CloseIcon from "@mui/icons-material/Close";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
+import ReportProblemOutlinedIcon from "@mui/icons-material/ReportProblemOutlined";
 import DetailedIcon from "@mui/icons-material/ViewComfyRounded";
 import SimpleIcon from "@mui/icons-material/ViewStreamRounded";
+import ZoomInIcon from "@mui/icons-material/ZoomIn";
+import ZoomOutIcon from "@mui/icons-material/ZoomOut";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { cleanKeyframesState } from "../../../../../redux/actions/tools/keyframesActions";
+import ImageGridList from "../../../../Shared/ImageGridList/ImageGridList";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
 import {
-  reverseImageSearch,
   SEARCH_ENGINE_SETTINGS,
+  reverseImageSearch,
 } from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+import { useKeyframes } from "../Hooks/usekeyframes";
 
 const KeyFramesResults = (props) => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Loccus/index.jsx
+++ b/src/components/NavItems/tools/Loccus/index.jsx
@@ -1,38 +1,34 @@
+import { useMutation } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+import Stack from "@mui/material/Stack";
+
+import { AudioFile } from "@mui/icons-material";
+
+import axios from "axios";
+import useAuthenticatedRequest from "components/Shared/Authentication/useAuthenticatedRequest";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { setError } from "redux/reducers/errorReducer";
+import { v4 as uuidv4 } from "uuid";
+
 import {
   resetLoccusAudio,
   setLoccusLoading,
   setLoccusResult,
 } from "../../../../redux/actions/tools/loccusActions";
-
-import axios from "axios";
-import {
-  Alert,
-  Box,
-  Card,
-  CardHeader,
-  Grid2,
-  LinearProgress,
-  Stack,
-} from "@mui/material";
-
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import { AudioFile } from "@mui/icons-material";
-
 import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import LoccusResults from "./loccusResults";
-
-import { setError } from "redux/reducers/errorReducer";
-import { isValidUrl } from "../../../Shared/Utils/URLUtils";
-
-import useAuthenticatedRequest from "components/Shared/Authentication/useAuthenticatedRequest";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import StringFileUploadField from "../../../Shared/StringFileUploadField";
+import { isValidUrl } from "../../../Shared/Utils/URLUtils";
 import { preprocessFileUpload } from "../../../Shared/Utils/fileUtils";
-
-import { v4 as uuidv4 } from "uuid";
-import { useMutation } from "@tanstack/react-query";
+import LoccusResults from "./loccusResults";
 
 const Loccus = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Loccus/loccusResults.jsx
+++ b/src/components/NavItems/tools/Loccus/loccusResults.jsx
@@ -1,46 +1,47 @@
-import React, { useEffect, useRef, useState } from "react";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Card,
-  CardHeader,
-  Divider,
-  Grid2,
-  IconButton,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
-import { Close, Download, ExpandMore } from "@mui/icons-material";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { useSelector } from "react-redux";
-import { useTrackEvent } from "Hooks/useAnalytics";
-import { getclientId } from "components/Shared/GoogleAnalytics/MatomoAnalytics";
-import GaugeChart from "react-gauge-chart";
 import { useWavesurfer } from "@wavesurfer/react";
-import CustomAlertScore from "../../../Shared/CustomAlertScore";
+import React, { useEffect, useRef, useState } from "react";
+import { Chart } from "react-chartjs-2";
+import GaugeChart from "react-gauge-chart";
+import { useSelector } from "react-redux";
 
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+
+import { Close, Download, ExpandMore } from "@mui/icons-material";
+
+import { useTrackEvent } from "Hooks/useAnalytics";
 import {
   CategoryScale,
   Chart as ChartJS,
+  Tooltip as ChartTooltip,
   Legend,
-  LinearScale,
   LineController,
   LineElement,
+  LinearScale,
   PointElement,
   TimeSeriesScale,
   Title,
-  Tooltip as ChartTooltip,
 } from "chart.js";
-import { Chart } from "react-chartjs-2";
 import "chartjs-adapter-dayjs-4/dist/chartjs-adapter-dayjs-4.esm";
+import { getclientId } from "components/Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
-import { exportReactElementAsJpg } from "../../../Shared/Utils/htmlUtils";
-import GaugeChartModalExplanation from "../../../Shared/GaugeChartResults/GaugeChartModalExplanation";
+
 import { ROLES } from "../../../../constants/roles";
+import CustomAlertScore from "../../../Shared/CustomAlertScore";
+import GaugeChartModalExplanation from "../../../Shared/GaugeChartResults/GaugeChartModalExplanation";
+import { exportReactElementAsJpg } from "../../../Shared/Utils/htmlUtils";
 
 const LoccusResults = ({
   result,

--- a/src/components/NavItems/tools/Magnifier/Magnifier.jsx
+++ b/src/components/NavItems/tools/Magnifier/Magnifier.jsx
@@ -1,25 +1,29 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-
-import { Box, Card, CardHeader, LinearProgress } from "@mui/material";
-
-import "tui-image-editor/dist/tui-image-editor.css";
-import ImageResult from "./Results/ImageResult";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import { useParams } from "react-router-dom";
+
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import LinearProgress from "@mui/material/LinearProgress";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { setError } from "redux/reducers/errorReducer";
+import "tui-image-editor/dist/tui-image-editor.css";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { imageMagnifier } from "../../../../constants/tools";
 import {
   resetMagnifierState,
   setMagnifierLoading,
   setMagnifierResult,
 } from "../../../../redux/actions/tools/magnifierActions";
-import { setError } from "redux/reducers/errorReducer";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
-import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
 import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import StringFileUploadField from "../../../Shared/StringFileUploadField";
-import { imageMagnifier } from "../../../../constants/tools";
+import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
+import ImageResult from "./Results/ImageResult";
 
 const Magnifier = () => {
   const { url } = useParams();

--- a/src/components/NavItems/tools/Magnifier/Results/ImageResult.jsx
+++ b/src/components/NavItems/tools/Magnifier/Results/ImageResult.jsx
@@ -1,26 +1,30 @@
 import React, { createRef, useState } from "react";
-import Loop from "./Loop";
-import Box from "@mui/material/Box";
 import { useDispatch, useSelector } from "react-redux";
-import Button from "@mui/material/Button";
-import "tui-image-editor/dist/tui-image-editor.css";
-import ImageEditor from "../Utils/ImageEditor";
-import Fade from "@mui/material/Fade";
-import Modal from "@mui/material/Modal";
+
 import Backdrop from "@mui/material/Backdrop";
-import { Grid2 } from "@mui/material";
-import { setMagnifierResult } from "../../../../../redux/actions/tools/magnifierActions";
-import { IconButton } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import {
-  reverseImageSearch,
-  SEARCH_ENGINE_SETTINGS,
-} from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+import Fade from "@mui/material/Fade";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import Modal from "@mui/material/Modal";
+
+import CloseIcon from "@mui/icons-material/Close";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import { ReverseSearchButtons } from "components/Shared/ReverseSearch/ReverseSearchButtons";
+import "tui-image-editor/dist/tui-image-editor.css";
+
+import { setMagnifierResult } from "../../../../../redux/actions/tools/magnifierActions";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import {
+  SEARCH_ENGINE_SETTINGS,
+  reverseImageSearch,
+} from "../../../../Shared/ReverseSearch/reverseSearchUtils";
+import ImageEditor from "../Utils/ImageEditor";
+import Loop from "./Loop";
 
 const myTheme = {
   "loadButton.backgroundColor": "#151515",

--- a/src/components/NavItems/tools/Metadata/Metadata.jsx
+++ b/src/components/NavItems/tools/Metadata/Metadata.jsx
@@ -1,29 +1,30 @@
 import React, { useEffect, useState } from "react";
-import Box from "@mui/material/Box";
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation, useParams } from "react-router-dom";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
-import MetadataImageResult from "./Results/MetadataImageResult";
-import MetadataVideoResult from "./Results/MetadataVideoResult";
+import Stack from "@mui/material/Stack";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import StringFileUploadField from "components/Shared/StringFileUploadField";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { imageMetadata } from "../../../../constants/tools";
+import { setMetadataMediaType } from "../../../../redux/reducers/tools/metadataReducer";
+import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import { CONTENT_TYPE, KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
 import useImageTreatment from "./Hooks/useImageTreatment";
 import useVideoTreatment from "./Hooks/useVideoTreatment";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
-import { useLocation, useParams } from "react-router-dom";
-
-import { CONTENT_TYPE, KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
-
-import Card from "@mui/material/Card";
-import CardHeader from "@mui/material/CardHeader";
-import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
-import { setMetadataMediaType } from "../../../../redux/reducers/tools/metadataReducer";
-
-import { Alert, Stack } from "@mui/material";
-import StringFileUploadField from "components/Shared/StringFileUploadField";
-import { imageMetadata } from "../../../../constants/tools";
+import MetadataImageResult from "./Results/MetadataImageResult";
+import MetadataVideoResult from "./Results/MetadataVideoResult";
 
 const Metadata = ({ mediaType }) => {
   const { url, type } = useParams();

--- a/src/components/NavItems/tools/Metadata/Results/MetadataImageResult.jsx
+++ b/src/components/NavItems/tools/Metadata/Results/MetadataImageResult.jsx
@@ -1,24 +1,27 @@
 import React from "react";
-import { Paper } from "@mui/material";
 import { useDispatch } from "react-redux";
-import Typography from "@mui/material/Typography";
-import TableBody from "@mui/material/TableBody";
-import TableRow from "@mui/material/TableRow";
-import TableCell from "@mui/material/TableCell";
-import Table from "@mui/material/Table";
+
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import MapIcon from "@mui/icons-material/Map";
-import Tooltip from "@mui/material/Tooltip";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import { IconButton } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import { cleanMetadataState } from "../../../../../redux/reducers/tools/metadataReducer";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
-
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
+import IconButton from "@mui/material/IconButton";
+import Paper from "@mui/material/Paper";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+
+import CloseIcon from "@mui/icons-material/Close";
+import MapIcon from "@mui/icons-material/Map";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { cleanMetadataState } from "../../../../../redux/reducers/tools/metadataReducer";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
 
 const MetadataImageResult = (props) => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/Metadata/Results/MetadataVideoResult.jsx
+++ b/src/components/NavItems/tools/Metadata/Results/MetadataVideoResult.jsx
@@ -1,22 +1,26 @@
 import React from "react";
 import { useDispatch } from "react-redux";
-import Typography from "@mui/material/Typography";
-import TableBody from "@mui/material/TableBody";
-import TableRow from "@mui/material/TableRow";
-import TableCell from "@mui/material/TableCell";
-import Table from "@mui/material/Table";
+
 import Box from "@mui/material/Box";
-import Tooltip from "@mui/material/Tooltip";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import { cleanMetadataState } from "../../../../../redux/reducers/tools/metadataReducer";
 import Button from "@mui/material/Button";
-import MapIcon from "@mui/icons-material/Map";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { IconButton } from "@mui/material";
+import IconButton from "@mui/material/IconButton";
+import Table from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableRow from "@mui/material/TableRow";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+
 import CloseIcon from "@mui/icons-material/Close";
+import MapIcon from "@mui/icons-material/Map";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { cleanMetadataState } from "../../../../../redux/reducers/tools/metadataReducer";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import OnClickInfo from "../../../../Shared/OnClickInfo/OnClickInfo";
 
 const MetadataVideoResult = (props) => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/OCR/OCR.jsx
+++ b/src/components/NavItems/tools/OCR/OCR.jsx
@@ -1,30 +1,31 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
+
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import HeaderTool from "@Shared/HeaderTool/HeaderTool";
 import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
+import { preprocessFileUpload } from "@Shared/Utils/fileUtils";
+import { setError } from "redux/reducers/errorReducer";
 
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { imageOcr } from "../../../../constants/tools";
 import {
   resetOcrState,
-  setb64InputFile,
   setOcrBinaryImage,
   setOcrErrorKey,
   setOcrInput,
   setOcrResult,
+  setb64InputFile,
 } from "../../../../redux/actions/tools/ocrActions";
-import OcrResult from "./Results/OcrResult";
-
-import { Box } from "@mui/material";
-import Card from "@mui/material/Card";
-import CardHeader from "@mui/material/CardHeader";
-import HeaderTool from "@Shared/HeaderTool/HeaderTool";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
-import { setError } from "redux/reducers/errorReducer";
-import { preprocessFileUpload } from "@Shared/Utils/fileUtils";
 import StringFileUploadField from "../../../Shared/StringFileUploadField";
 import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
-import { imageOcr } from "../../../../constants/tools";
+import OcrResult from "./Results/OcrResult";
 
 const OCR = () => {
   const { url } = useParams();

--- a/src/components/NavItems/tools/OCR/Results/OcrResult.jsx
+++ b/src/components/NavItems/tools/OCR/Results/OcrResult.jsx
@@ -4,29 +4,34 @@ import { useDispatch, useSelector } from "react-redux";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
-import { CardContent, Grid2, TextField } from "@mui/material";
+import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
 import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
 import IconButton from "@mui/material/IconButton";
 import LinearProgress from "@mui/material/LinearProgress";
 import MenuItem from "@mui/material/MenuItem";
+import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
+
 import WarningOutlined from "@mui/icons-material/WarningOutlined";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import { setError } from "redux/reducers/errorReducer";
+
 import {
   resetOcrState,
   setOcrReprocess,
   setReprocessOpen,
   setSelectedScript,
 } from "../../../../../redux/actions/tools/ocrActions";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import {
+  SEARCH_ENGINE_SETTINGS,
+  reverseImageSearch,
+} from "../../../../Shared/ReverseSearch/reverseSearchUtils";
 import { TextCopy } from "../../../../Shared/Utils/TextCopy";
 import { Translate } from "../../../../Shared/Utils/Translate";
-import {
-  reverseImageSearch,
-  SEARCH_ENGINE_SETTINGS,
-} from "../../../../Shared/ReverseSearch/reverseSearchUtils";
 
 const OcrResult = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/SemanticSearch/SemanticSearchResults.jsx
+++ b/src/components/NavItems/tools/SemanticSearch/SemanticSearchResults.jsx
@@ -1,12 +1,19 @@
 import React, { useState } from "react";
-import { Box, Card, Pagination, Stack, Typography } from "@mui/material";
-import SelectSmall from "./components/SelectSmall";
-import ResultDisplayItem from "./components/ResultDisplayItem";
-import { getLanguageName } from "../../../Shared/Utils/languageUtils";
-import { i18nLoadNamespace } from "../../../Shared/Languages/i18nLoadNamespace";
+
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import Pagination from "@mui/material/Pagination";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import dayjs from "dayjs";
 import LocaleData from "dayjs/plugin/localeData";
 import localizedFormat from "dayjs/plugin/localizedFormat";
+
+import { i18nLoadNamespace } from "../../../Shared/Languages/i18nLoadNamespace";
+import { getLanguageName } from "../../../Shared/Utils/languageUtils";
+import ResultDisplayItem from "./components/ResultDisplayItem";
+import SelectSmall from "./components/SelectSmall";
 
 const SemanticSearchResults = (searchResults) => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/SemanticSearch");

--- a/src/components/NavItems/tools/SemanticSearch/components/ResultDisplayItem.jsx
+++ b/src/components/NavItems/tools/SemanticSearch/components/ResultDisplayItem.jsx
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
 import { useLocation } from "react-router-dom";
-import {
-  Avatar,
-  Box,
-  Chip,
-  Divider,
-  Grid2,
-  Link,
-  Stack,
-  Typography,
-} from "@mui/material";
+
+import Avatar from "@mui/material/Avatar";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import { i18nLoadNamespace } from "../../../../Shared/Languages/i18nLoadNamespace";
 
 const ResultDisplayItem = ({

--- a/src/components/NavItems/tools/SemanticSearch/index.jsx
+++ b/src/components/NavItems/tools/SemanticSearch/index.jsx
@@ -1,42 +1,43 @@
 import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
-import {
-  Alert,
-  Backdrop,
-  Box,
-  Button,
-  Card,
-  Collapse,
-  Fade,
-  IconButton,
-  Link,
-  Modal,
-  Skeleton,
-  Stack,
-  TextField,
-  Typography,
-} from "@mui/material";
-import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+
+import Alert from "@mui/material/Alert";
+import Backdrop from "@mui/material/Backdrop";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import Collapse from "@mui/material/Collapse";
+import Fade from "@mui/material/Fade";
+import IconButton from "@mui/material/IconButton";
+import Link from "@mui/material/Link";
+import Modal from "@mui/material/Modal";
+import Skeleton from "@mui/material/Skeleton";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+
 import {
   Close,
   KeyboardArrowDown,
   KeyboardArrowUp,
   ManageSearch,
 } from "@mui/icons-material";
+
+import LoadingButton from "@mui/lab/LoadingButton";
+import { DatePicker } from "@mui/x-date-pickers";
+import axios from "axios";
+import DateAndTimePicker from "components/Shared/DateTimePicker/DateAndTimePicker";
+import dayjs from "dayjs";
+import isEqual from "lodash/isEqual";
+
+import languageDictionary from "../../../../LocalDictionary/iso-639-1-languages";
+import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+import { i18nLoadNamespace } from "../../../Shared/Languages/i18nLoadNamespace";
+import { getLanguageName } from "../../../Shared/Utils/languageUtils";
 import SemanticSearchResults from "./SemanticSearchResults";
 import CheckboxesTags from "./components/CheckboxesTags";
-import { DatePicker } from "@mui/x-date-pickers";
 import SelectSmall from "./components/SelectSmall";
-import LoadingButton from "@mui/lab/LoadingButton";
-
-import axios from "axios";
-import isEqual from "lodash/isEqual";
-import dayjs from "dayjs";
-import { getLanguageName } from "../../../Shared/Utils/languageUtils";
-import { i18nLoadNamespace } from "../../../Shared/Languages/i18nLoadNamespace";
-import languageDictionary from "../../../../LocalDictionary/iso-639-1-languages";
-import { useSelector } from "react-redux";
-import DateAndTimePicker from "components/Shared/DateTimePicker/DateAndTimePicker";
 
 const SemanticSearch = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/SemanticSearch");

--- a/src/components/NavItems/tools/SyntheticImageDetection/NddDatagrid.jsx
+++ b/src/components/NavItems/tools/SyntheticImageDetection/NddDatagrid.jsx
@@ -1,18 +1,17 @@
 import * as React from "react";
-import Box from "@mui/material/Box";
-import { DataGrid, GridActionsCellItem } from "@mui/x-data-grid";
-import Link from "@mui/material/Link";
-import { Chip, Grid2, Stack, Typography } from "@mui/material";
-import { i18nLoadNamespace } from "../../../Shared/Languages/i18nLoadNamespace";
-import {
-  getAlertColor,
-  getAlertLabel,
-  getPercentageColorCode,
-} from "./syntheticImageDetectionResults";
-import { OpenInNew } from "@mui/icons-material";
 import { useSelector } from "react-redux";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
 
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Grid2 from "@mui/material/Grid2";
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import { OpenInNew } from "@mui/icons-material";
+
+import { DataGrid, GridActionsCellItem } from "@mui/x-data-grid";
 import {
   arSD,
   deDE,
@@ -22,6 +21,13 @@ import {
   frFR,
   itIT,
 } from "@mui/x-data-grid/locales";
+
+import { i18nLoadNamespace } from "../../../Shared/Languages/i18nLoadNamespace";
+import {
+  getAlertColor,
+  getAlertLabel,
+  getPercentageColorCode,
+} from "./syntheticImageDetectionResults";
 
 const languages = {
   en: enUS,

--- a/src/components/NavItems/tools/SyntheticImageDetection/index.jsx
+++ b/src/components/NavItems/tools/SyntheticImageDetection/index.jsx
@@ -1,40 +1,38 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+import Stack from "@mui/material/Stack";
+import Switch from "@mui/material/Switch";
+
+import { Gradient } from "@mui/icons-material";
+
+import axios from "axios";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { setError } from "redux/reducers/errorReducer";
+
+import { ROLES } from "../../../../constants/roles";
 import {
   resetSyntheticImageDetectionImage,
   setSyntheticImageDetectionLoading,
   setSyntheticImageDetectionNearDuplicates,
   setSyntheticImageDetectionResult,
 } from "../../../../redux/actions/tools/syntheticImageDetectionActions";
-
-import axios from "axios";
-import {
-  Alert,
-  Box,
-  Card,
-  CardHeader,
-  FormControlLabel,
-  FormGroup,
-  Grid2,
-  LinearProgress,
-  Stack,
-  Switch,
-} from "@mui/material";
-
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import { Gradient } from "@mui/icons-material";
-
 import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { isValidUrl } from "../../../Shared/Utils/URLUtils";
-import SyntheticImageDetectionResults from "./syntheticImageDetectionResults";
-
-import { setError } from "redux/reducers/errorReducer";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import StringFileUploadField from "../../../Shared/StringFileUploadField";
+import { isValidUrl } from "../../../Shared/Utils/URLUtils";
 import { preprocessFileUpload } from "../../../Shared/Utils/fileUtils";
 import { syntheticImageDetectionAlgorithms } from "./SyntheticImageDetectionAlgorithms";
-import { ROLES } from "../../../../constants/roles";
-import { useLocation } from "react-router-dom";
+import SyntheticImageDetectionResults from "./syntheticImageDetectionResults";
 
 const SyntheticImageDetection = () => {
   const location = useLocation();

--- a/src/components/NavItems/tools/SyntheticImageDetection/syntheticImageDetectionResults.jsx
+++ b/src/components/NavItems/tools/SyntheticImageDetection/syntheticImageDetectionResults.jsx
@@ -1,44 +1,46 @@
 import React, { useEffect, useRef, useState } from "react";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Alert,
-  Box,
-  Card,
-  CardContent,
-  CardHeader,
-  Chip,
-  Grid2,
-  IconButton,
-  Stack,
-} from "@mui/material";
-import { Close, Download, ExpandMore } from "@mui/icons-material";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import GaugeChart from "react-gauge-chart";
 import { useSelector } from "react-redux";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardContent from "@mui/material/CardContent";
+import CardHeader from "@mui/material/CardHeader";
+import Chip from "@mui/material/Chip";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemText from "@mui/material/ListItemText";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+
+import { Close, Download, ExpandMore } from "@mui/icons-material";
+
 import { useTrackEvent } from "Hooks/useAnalytics";
 import { getclientId } from "components/Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import CustomAlertScore from "../../../Shared/CustomAlertScore";
-import GaugeChart from "react-gauge-chart";
-import Tooltip from "@mui/material/Tooltip";
+import GaugeChartModalExplanation from "../../../Shared/GaugeChartResults/GaugeChartModalExplanation";
 import { exportReactElementAsJpg } from "../../../Shared/Utils/htmlUtils";
 import NddDatagrid from "./NddDatagrid";
 import {
-  canUserDisplayAlgorithmResults,
   DETECTION_THRESHOLDS,
+  SyntheticImageDetectionAlgorithm,
+  canUserDisplayAlgorithmResults,
   getSyntheticImageDetectionAlgorithmFromApiName,
   gigaGanWebpR50Grip,
   ldmWebpR50Grip,
   proGanWebpR50Grip,
-  SyntheticImageDetectionAlgorithm,
   syntheticImageDetectionAlgorithms,
 } from "./SyntheticImageDetectionAlgorithms";
-import GaugeChartModalExplanation from "../../../Shared/GaugeChartResults/GaugeChartModalExplanation";
-import Typography from "@mui/material/Typography";
-import Divider from "@mui/material/Divider";
-import ListItem from "@mui/material/ListItem";
-import ListItemText from "@mui/material/ListItemText";
-import List from "@mui/material/List";
 
 /**
  * Returns the alert color code for the given percentage n

--- a/src/components/NavItems/tools/Thumbnails/Thumbnails.jsx
+++ b/src/components/NavItems/tools/Thumbnails/Thumbnails.jsx
@@ -1,39 +1,43 @@
 import React, { useEffect, useState } from "react";
-import TextField from "@mui/material/TextField";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
+
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import ImageGridList from "@Shared/ImageGridList/ImageGridList";
-import { useDispatch, useSelector } from "react-redux";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import Checkbox from "@mui/material/Checkbox";
 import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
-import { Grid2, IconButton } from "@mui/material";
+import FormGroup from "@mui/material/FormGroup";
+import Grid2 from "@mui/material/Grid2";
+import IconButton from "@mui/material/IconButton";
+import LinearProgress from "@mui/material/LinearProgress";
+import TextField from "@mui/material/TextField";
+
 import CloseIcon from "@mui/icons-material/Close";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import HeaderTool from "@Shared/HeaderTool/HeaderTool";
+import ImageGridList from "@Shared/ImageGridList/ImageGridList";
+import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
+import OnClickInfo from "@Shared/OnClickInfo/OnClickInfo";
+import {
+  SEARCH_ENGINE_SETTINGS,
+  reverseImageSearch,
+  reverseImageSearchAll,
+} from "@Shared/ReverseSearch/reverseSearchUtils";
+import { setError } from "redux/reducers/errorReducer";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
 import { loadImageSize, useLoading } from "../../../../Hooks/useInput";
+import { thumbnails } from "../../../../constants/tools";
 import {
   cleanThumbnailsState,
   setThumbnailsLoading,
   setThumbnailsResult,
 } from "../../../../redux/reducers/tools/thumbnailsReducer";
-import { setError } from "redux/reducers/errorReducer";
-import Checkbox from "@mui/material/Checkbox";
-import FormGroup from "@mui/material/FormGroup";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
-import OnClickInfo from "@Shared/OnClickInfo/OnClickInfo";
-import { useParams } from "react-router-dom";
-
-import Card from "@mui/material/Card";
-import CardHeader from "@mui/material/CardHeader";
-import HeaderTool from "@Shared/HeaderTool/HeaderTool";
-import LinearProgress from "@mui/material/LinearProgress";
-import {
-  reverseImageSearch,
-  reverseImageSearchAll,
-  SEARCH_ENGINE_SETTINGS,
-} from "@Shared/ReverseSearch/reverseSearchUtils";
-import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
-import { thumbnails } from "../../../../constants/tools";
 
 const Thumbnails = () => {
   const { url } = useParams();

--- a/src/components/NavItems/tools/TwitterAdvancedSearch/TwitterAdvancedSearch.jsx
+++ b/src/components/NavItems/tools/TwitterAdvancedSearch/TwitterAdvancedSearch.jsx
@@ -1,27 +1,30 @@
-import { Box } from "@mui/material";
 import React, { useState } from "react";
 import { useSelector } from "react-redux";
-import TextField from "@mui/material/TextField";
+
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import { useInput } from "../../../../Hooks/useInput";
-import { createUrl } from "./createUrl";
-import RadioGroup from "@mui/material/RadioGroup";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import FormControl from "@mui/material/FormControl";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import Radio from "@mui/material/Radio";
-import FormControl from "@mui/material/FormControl";
+import RadioGroup from "@mui/material/RadioGroup";
+import TextField from "@mui/material/TextField";
+
+import DateAndTimePicker from "@Shared/DateTimePicker/DateAndTimePicker";
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import HeaderTool from "@Shared/HeaderTool/HeaderTool";
+import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
 import useMyStyles, {
   myCardStyles,
 } from "@Shared/MaterialUiStyles/useMyStyles";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
-import Alert from "@mui/material/Alert";
-import Card from "@mui/material/Card";
-import CardHeader from "@mui/material/CardHeader";
-import HeaderTool from "@Shared/HeaderTool/HeaderTool";
-import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
-import DateAndTimePicker from "@Shared/DateTimePicker/DateAndTimePicker";
 import dayjs from "dayjs";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { useInput } from "../../../../Hooks/useInput";
 import { searchTwitter } from "../../../../constants/tools";
+import { createUrl } from "./createUrl";
 
 const TwitterAdvancedSearch = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/TwitterSna/TwitterSna.jsx
+++ b/src/components/NavItems/tools/TwitterSna/TwitterSna.jsx
@@ -1,56 +1,54 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { setError } from "redux/reducers/errorReducer";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CardHeader from "@mui/material/CardHeader";
+import Checkbox from "@mui/material/Checkbox";
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Grid2 from "@mui/material/Grid2";
+import InputLabel from "@mui/material/InputLabel";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
+import Select from "@mui/material/Select";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+
+import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExcludeIcon from "@mui/icons-material/HighlightOff";
+import LaptopIcon from "@mui/icons-material/Laptop";
+//import DoneIcon from '@mui/icons-material/Done';
+import PermMediaIcon from "@mui/icons-material/PermMedia";
+import PersonOutlineIcon from "@mui/icons-material/PersonOutline";
+import GlobeIcon from "@mui/icons-material/Public";
+import SearchIcon from "@mui/icons-material/Search";
+import TranslateIcon from "@mui/icons-material/Translate";
+
+import { convertMomentToGMT } from "@Shared/DateTimePicker/convertToGMT";
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import DateAndTimePicker from "components/Shared/DateTimePicker/DateAndTimePicker";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import dateFormat from "dateformat";
+import dayjs from "dayjs";
 import _ from "lodash";
+import { setError } from "redux/reducers/errorReducer";
+
+import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { dataAnalysisSna } from "../../../../constants/tools";
+import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
 import useMyStyles, {
   myCardStyles,
 } from "../../../Shared/MaterialUiStyles/useMyStyles";
-
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Button,
-  Card,
-  CardHeader,
-  Checkbox,
-  FormControl,
-  FormControlLabel,
-  Grid2,
-  InputLabel,
-  Radio,
-  RadioGroup,
-  Select,
-  TextField,
-  Typography,
-} from "@mui/material";
-
 import OnWarningInfo from "../../../Shared/OnClickInfo/OnWarningInfo";
-import SearchIcon from "@mui/icons-material/Search";
-import { convertMomentToGMT } from "@Shared/DateTimePicker/convertToGMT";
-import useTwitterSnaRequest from "./Hooks/useTwitterSnaRequest";
 import { replaceAll } from "../TwitterAdvancedSearch/createUrl";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
-import { useTrackEvent } from "../../../../Hooks/useAnalytics";
-import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
-
-import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
-import GlobeIcon from "@mui/icons-material/Public";
-import ExcludeIcon from "@mui/icons-material/HighlightOff";
-import TranslateIcon from "@mui/icons-material/Translate";
-import PersonOutlineIcon from "@mui/icons-material/PersonOutline"; //import DoneIcon from '@mui/icons-material/Done';
-import PermMediaIcon from "@mui/icons-material/PermMedia";
-import LaptopIcon from "@mui/icons-material/Laptop";
-
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-
-import { createTheme, ThemeProvider } from "@mui/material/styles";
-import DateAndTimePicker from "components/Shared/DateTimePicker/DateAndTimePicker";
-import dayjs from "dayjs";
-import { dataAnalysisSna } from "../../../../constants/tools";
+import useTwitterSnaRequest from "./Hooks/useTwitterSnaRequest";
 
 const TwitterSna = () => {
   const theme = createTheme({

--- a/src/components/NavItems/tools/VideoRights/Results/VideoRightsResults.jsx
+++ b/src/components/NavItems/tools/VideoRights/Results/VideoRightsResults.jsx
@@ -1,25 +1,30 @@
 import React from "react";
-import { IconButton, Paper } from "@mui/material";
-import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
-import Typography from "@mui/material/Typography";
-import BlockIcon from "@mui/icons-material/Block";
-import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import Button from "@mui/material/Button";
-import Box from "@mui/material/Box";
-import YouTubeIcon from "@mui/icons-material/YouTube";
-import TwitterIcon from "@mui/icons-material/Twitter";
-import FacebookIcon from "@mui/icons-material/Facebook";
-import Divider from "@mui/material/Divider";
-import invidLogo from "../images/InVID-logo.svg?url";
-import Icon from "@mui/material/Icon";
-import { Grid2 } from "@mui/material";
-import { cleanVideoRightsState } from "../../../../../redux/actions/tools/videoRightsActions";
 import { useDispatch } from "react-redux";
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import Divider from "@mui/material/Divider";
+import Grid2 from "@mui/material/Grid2";
+import Icon from "@mui/material/Icon";
+import IconButton from "@mui/material/IconButton";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+
+import BlockIcon from "@mui/icons-material/Block";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import CloseIcon from "@mui/icons-material/Close";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import FacebookIcon from "@mui/icons-material/Facebook";
+import TwitterIcon from "@mui/icons-material/Twitter";
+import YouTubeIcon from "@mui/icons-material/YouTube";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import { cleanVideoRightsState } from "../../../../../redux/actions/tools/videoRightsActions";
+import useMyStyles from "../../../../Shared/MaterialUiStyles/useMyStyles";
+import invidLogo from "../images/InVID-logo.svg?url";
 
 const VideoRightsResults = (props) => {
   const classes = useMyStyles();

--- a/src/components/NavItems/tools/VideoRights/VideoRights.jsx
+++ b/src/components/NavItems/tools/VideoRights/VideoRights.jsx
@@ -1,24 +1,27 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import TextField from "@mui/material/TextField";
+//import { useTrackEvent } from "../../../../Hooks/useAnalytics";
+import { useParams } from "react-router-dom";
+
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import LinearProgress from "@mui/material/LinearProgress";
-import useVideoRightsTreatment from "./Hooks/useVideoRightsTreatment";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import VideoRightsResults from "./Results/VideoRightsResults";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics"; //import { useTrackEvent } from "../../../../Hooks/useAnalytics";
-import { useParams } from "react-router-dom";
-import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
-
 import Card from "@mui/material/Card";
 import CardHeader from "@mui/material/CardHeader";
-import { setVideoRightsLoading } from "../../../../redux/actions/tools/videoRightsActions";
-import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
-import { Grid2 } from "@mui/material";
+import Grid2 from "@mui/material/Grid2";
+import LinearProgress from "@mui/material/LinearProgress";
+import TextField from "@mui/material/TextField";
+
+import { getclientId } from "@Shared/GoogleAnalytics/MatomoAnalytics";
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
 import { useTrackEvent } from "../../../../Hooks/useAnalytics";
 import { videoRights } from "../../../../constants/tools";
+import { setVideoRightsLoading } from "../../../../redux/actions/tools/videoRightsActions";
+import HeaderTool from "../../../Shared/HeaderTool/HeaderTool";
+import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import { KNOWN_LINKS } from "../../Assistant/AssistantRuleBook";
+import useVideoRightsTreatment from "./Hooks/useVideoRightsTreatment";
+import VideoRightsResults from "./Results/VideoRightsResults";
 
 const VideoRights = () => {
   const { url } = useParams();

--- a/src/components/NavItems/tutorial/tutorial.jsx
+++ b/src/components/NavItems/tutorial/tutorial.jsx
@@ -1,22 +1,23 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Box,
-  Paper,
-  Typography,
-} from "@mui/material";
-import CustomTile from "../../Shared/CustomTitle/CustomTitle";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 
-import popUpEn from "./images/popUpImage/popUp_EN.png";
-import popUpFr from "./images/popUpImage/popUp_FR.png";
-import popUpEs from "./images/popUpImage/popUp_ES.png";
-import popUpEl from "./images/popUpImage/popUp_EL.png";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+
+import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import CustomTile from "../../Shared/CustomTitle/CustomTitle";
+import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
+import popUpEl from "./images/popUpImage/popUp_EL.png";
+import popUpEn from "./images/popUpImage/popUp_EN.png";
+import popUpEs from "./images/popUpImage/popUp_ES.png";
+import popUpFr from "./images/popUpImage/popUp_FR.png";
 
 // from https://material-ui.com/customization/default-theme/
 // used typography body 2 style

--- a/src/components/NotificationSnackbar/index.jsx
+++ b/src/components/NotificationSnackbar/index.jsx
@@ -1,5 +1,8 @@
 import { React } from "react";
-import { Alert, Snackbar } from "@mui/material";
+
+import Alert from "@mui/material/Alert";
+import Snackbar from "@mui/material/Snackbar";
+
 import { i18nLoadNamespace } from "../Shared/Languages/i18nLoadNamespace";
 
 const NotificationSnackbar = ({ openAlert, setOpenAlert }) => {

--- a/src/components/PopUp/PopUp.jsx
+++ b/src/components/PopUp/PopUp.jsx
@@ -1,15 +1,19 @@
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { Box, Button, Grid2 } from "@mui/material";
-import LogoVera from "../NavBar/images/SVG/Navbar/vera-logo_black.svg?url";
-import LogoInVidWeverify from "../NavBar/images/SVG/Navbar/invid_weverify.svg?url";
-import LogoEuCom from "../NavBar/images/SVG/Navbar/ep-logo.svg?url";
-import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Grid2 from "@mui/material/Grid2";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { changeLanguage } from "../../redux/reducers/languageReducer";
-import { getSupportedBrowserLanguage } from "../Shared/Languages/getSupportedBrowserLanguage";
 import { ROLES } from "constants/roles";
+
+import { changeLanguage } from "../../redux/reducers/languageReducer";
+import LogoEuCom from "../NavBar/images/SVG/Navbar/ep-logo.svg?url";
+import LogoInVidWeverify from "../NavBar/images/SVG/Navbar/invid_weverify.svg?url";
+import LogoVera from "../NavBar/images/SVG/Navbar/vera-logo_black.svg?url";
+import { getSupportedBrowserLanguage } from "../Shared/Languages/getSupportedBrowserLanguage";
+import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
 
 const navigator = window.browser ? window.browser : window.chrome;
 

--- a/src/components/Shared/CopyButton/index.jsx
+++ b/src/components/Shared/CopyButton/index.jsx
@@ -1,7 +1,10 @@
-import { IconButton, Tooltip } from "@mui/material";
+import React, { useState } from "react";
+
+import IconButton from "@mui/material/IconButton";
+import Tooltip from "@mui/material/Tooltip";
+
 import DoneIcon from "@mui/icons-material/Done";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
-import React, { useState } from "react";
 
 const CopyButton = ({ strToCopy, labelBeforeCopy, labelAfterCopy }) => {
   if (typeof strToCopy !== "string") {

--- a/src/components/Shared/CustomAlertScore/index.jsx
+++ b/src/components/Shared/CustomAlertScore/index.jsx
@@ -1,8 +1,11 @@
 import React from "react";
-import { Alert, Grid2 } from "@mui/material";
+
+import Alert from "@mui/material/Alert";
+import Grid2 from "@mui/material/Grid2";
+import Typography from "@mui/material/Typography";
+
 import CopyButton from "../CopyButton";
 import { i18nLoadNamespace } from "../Languages/i18nLoadNamespace";
-import Typography from "@mui/material/Typography";
 
 const CustomAlertScore = ({
   score,

--- a/src/components/Shared/DetectionProgressBar/DetectionProgressBar.jsx
+++ b/src/components/Shared/DetectionProgressBar/DetectionProgressBar.jsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
+
 import Box from "@mui/material/Box";
 import CardMedia from "@mui/material/CardMedia";
-import { Grid2 } from "@mui/material";
+import Grid2 from "@mui/material/Grid2";
 import Typography from "@mui/material/Typography";
-import MakoScale from "../../NavBar/images/SVG/MakoScale.png";
+
 import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+
+import MakoScale from "../../NavBar/images/SVG/MakoScale.png";
 
 export const DetectionProgressBar = (props) => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Forensic");

--- a/src/components/Shared/GaugeChartResults/GaugeChartModalExplanation/index.jsx
+++ b/src/components/Shared/GaugeChartResults/GaugeChartModalExplanation/index.jsx
@@ -1,14 +1,14 @@
 import React, { useState } from "react";
-import {
-  Backdrop,
-  Box,
-  Fade,
-  IconButton,
-  Link,
-  Modal,
-  Stack,
-  Typography,
-} from "@mui/material";
+
+import Backdrop from "@mui/material/Backdrop";
+import Box from "@mui/material/Box";
+import Fade from "@mui/material/Fade";
+import IconButton from "@mui/material/IconButton";
+import Link from "@mui/material/Link";
+import Modal from "@mui/material/Modal";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import { Close, Square } from "@mui/icons-material";
 
 /**

--- a/src/components/Shared/GaugeChartResults/GaugeChartResult.jsx
+++ b/src/components/Shared/GaugeChartResults/GaugeChartResult.jsx
@@ -1,22 +1,23 @@
-import { Download, ExpandMore } from "@mui/icons-material";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Alert,
-  Box,
-  Chip,
-  Divider,
-  IconButton,
-  Stack,
-  Tooltip,
-  Typography,
-} from "@mui/material";
 import React, { useRef, useState } from "react";
 import GaugeChart from "react-gauge-chart";
-import GaugeChartModalExplanation from "./GaugeChartModalExplanation";
+
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
+
+import { Download, ExpandMore } from "@mui/icons-material";
+
 import CustomAlertScore from "../CustomAlertScore";
 import { exportReactElementAsJpg } from "../Utils/htmlUtils";
+import GaugeChartModalExplanation from "./GaugeChartModalExplanation";
 
 /**
  *

--- a/src/components/Shared/HeaderTool/HeaderTool.jsx
+++ b/src/components/Shared/HeaderTool/HeaderTool.jsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { Box, Grid2, Typography } from "@mui/material";
+
+import Box from "@mui/material/Box";
+import Grid2 from "@mui/material/Grid2";
+import Typography from "@mui/material/Typography";
 
 /**
  *

--- a/src/components/Shared/LinearProgressWithLabel/LinearProgressWithLabel.jsx
+++ b/src/components/Shared/LinearProgressWithLabel/LinearProgressWithLabel.jsx
@@ -1,10 +1,10 @@
 import React from "react";
-import {
-  Typography,
-  LinearProgress,
-  linearProgressClasses,
-  Box,
-} from "@mui/material";
+
+import { linearProgressClasses } from "@mui/material";
+import Box from "@mui/material/Box";
+import LinearProgress from "@mui/material/LinearProgress";
+import Typography from "@mui/material/Typography";
+
 import styled from "@emotion/styled";
 
 const BorderLinearProgress = styled(LinearProgress)(({ theme, value }) => ({

--- a/src/components/Shared/ReverseSearch/ReverseSearchButtons.jsx
+++ b/src/components/Shared/ReverseSearch/ReverseSearchButtons.jsx
@@ -1,8 +1,12 @@
 import React from "react";
-import { Button, Grid2 } from "@mui/material";
+
+import Button from "@mui/material/Button";
+import Grid2 from "@mui/material/Grid2";
+
 import { SEARCH_ENGINE_SETTINGS } from "components/Shared/ReverseSearch/reverseSearchUtils";
-import useMyStyles from "../MaterialUiStyles/useMyStyles";
+
 import { i18nLoadNamespace } from "../Languages/i18nLoadNamespace";
+import useMyStyles from "../MaterialUiStyles/useMyStyles";
 import { IMAGE_FORMATS } from "./utils/searchUtils";
 
 export const ReverseSearchButtons = ({

--- a/src/components/Shared/StringFileUploadField/index.jsx
+++ b/src/components/Shared/StringFileUploadField/index.jsx
@@ -1,18 +1,20 @@
 import React, { useRef, useState } from "react";
+
 import Box from "@mui/material/Box";
-import {
-  Button,
-  ButtonGroup,
-  Grid2,
-  Stack,
-  TextField,
-  Typography,
-} from "@mui/material";
-import FolderOpenIcon from "@mui/icons-material/FolderOpen";
+import Button from "@mui/material/Button";
+import ButtonGroup from "@mui/material/ButtonGroup";
+import Grid2 from "@mui/material/Grid2";
+import Stack from "@mui/material/Stack";
+import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
+import { green } from "@mui/material/colors";
+
 import CloseIcon from "@mui/icons-material/Close";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
+
 import LoadingButton from "@mui/lab/LoadingButton";
 import accept from "attr-accept";
-import { green } from "@mui/material/colors";
+
 import { i18nLoadNamespace } from "../Languages/i18nLoadNamespace";
 
 /**

--- a/src/components/SideMenu/index.jsx
+++ b/src/components/SideMenu/index.jsx
@@ -1,20 +1,20 @@
 import React, { useEffect, useRef, useState } from "react";
-import {
-  Box,
-  Button,
-  Collapse,
-  Divider,
-  Drawer,
-  List,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  ListSubheader,
-  Stack,
-  Typography,
-} from "@mui/material";
-import clsx from "clsx";
+import { useDispatch, useSelector } from "react-redux";
 import { Link, useNavigate } from "react-router-dom";
+
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import Collapse from "@mui/material/Collapse";
+import Divider from "@mui/material/Divider";
+import Drawer from "@mui/material/Drawer";
+import List from "@mui/material/List";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import ListSubheader from "@mui/material/ListSubheader";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import {
   Audiotrack,
   ChevronLeft,
@@ -23,24 +23,26 @@ import {
   ExpandMore,
   MoreHoriz,
 } from "@mui/icons-material";
-import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
-import { i18nLoadNamespace } from "../Shared/Languages/i18nLoadNamespace";
-import { useDispatch, useSelector } from "react-redux";
-import VideoIcon from "../NavBar/images/SVG/Video/Video.svg";
-import ImageIcon from "../NavBar/images/SVG/Image/Images.svg";
-import SearchIcon from "../NavBar/images/SVG/Search/Search.svg";
-import DataIcon from "../NavBar/images/SVG/DataAnalysis/Data_analysis.svg";
+
+import clsx from "clsx";
+
+import { ROLES } from "../../constants/roles";
 import {
-  canUserSeeTool,
+  TOOLS_CATEGORIES,
   TOOL_GROUPS,
   TOOL_STATUS_ICON,
-  TOOLS_CATEGORIES,
+  canUserSeeTool,
   toolsHome,
 } from "../../constants/tools";
-import { ROLES } from "../../constants/roles";
-import { selectTopMenuItem } from "../../redux/reducers/navReducer";
 import { TOP_MENU_ITEMS } from "../../constants/topMenuItems";
+import { selectTopMenuItem } from "../../redux/reducers/navReducer";
 import { selectTool } from "../../redux/reducers/tools/toolReducer";
+import DataIcon from "../NavBar/images/SVG/DataAnalysis/Data_analysis.svg";
+import ImageIcon from "../NavBar/images/SVG/Image/Images.svg";
+import SearchIcon from "../NavBar/images/SVG/Search/Search.svg";
+import VideoIcon from "../NavBar/images/SVG/Video/Video.svg";
+import { i18nLoadNamespace } from "../Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
 import SideMenuElement from "./sideMenuElement";
 
 const SideMenu = ({ tools, setOpenAlert }) => {

--- a/src/components/SideMenu/sideMenuElement.jsx
+++ b/src/components/SideMenu/sideMenuElement.jsx
@@ -1,11 +1,11 @@
 import React from "react";
-import {
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-  Stack,
-  Typography,
-} from "@mui/material";
+
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
 import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
 
 /**

--- a/src/components/TopMenu/index.jsx
+++ b/src/components/TopMenu/index.jsx
@@ -1,17 +1,24 @@
 import React, { useEffect, useState } from "react";
-import { AppBar, Grid2, Stack, Tab, Tabs, Toolbar } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { Link, useNavigate } from "react-router-dom";
+
+import AppBar from "@mui/material/AppBar";
+import Grid2 from "@mui/material/Grid2";
+import Stack from "@mui/material/Stack";
+import Tab from "@mui/material/Tab";
+import Tabs from "@mui/material/Tabs";
+import Toolbar from "@mui/material/Toolbar";
+
+import { toolsHome } from "../../constants/tools";
+import { selectTopMenuItem } from "../../redux/reducers/navReducer";
+import { resetToolSelected } from "../../redux/reducers/tools/toolReducer";
 import LogoEuCom from "../NavBar/images/SVG/Navbar/ep-logo.svg";
 import LogoInVidWeverify from "../NavBar/images/SVG/Navbar/invid_weverify.svg";
 import LogoVera from "../NavBar/images/SVG/Navbar/vera-logo_black.svg";
-import { Link, useNavigate } from "react-router-dom";
-import AdvancedTools from "../NavItems/tools/Alltools/AdvancedTools/AdvancedTools";
 import Languages from "../NavItems/languages/languages";
-import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
-import { useDispatch, useSelector } from "react-redux";
+import AdvancedTools from "../NavItems/tools/Alltools/AdvancedTools/AdvancedTools";
 import { i18nLoadNamespace } from "../Shared/Languages/i18nLoadNamespace";
-import { selectTopMenuItem } from "../../redux/reducers/navReducer";
-import { toolsHome } from "../../constants/tools";
-import { resetToolSelected } from "../../redux/reducers/tools/toolReducer";
+import useMyStyles from "../Shared/MaterialUiStyles/useMyStyles";
 
 const TopMenu = ({ topMenuItems }) => {
   const classes = useMyStyles();

--- a/src/constants/tools.jsx
+++ b/src/constants/tools.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
-import { SvgIcon } from "@mui/material";
+import SvgIcon from "@mui/material/SvgIcon";
+
 import {
   Archive as ArchiveIcon,
   AudioFile,
@@ -8,54 +9,51 @@ import {
   ManageSearch,
 } from "@mui/icons-material";
 
-import ToolsIcon from "../components/NavBar/images/SVG/Navbar/Tools.svg";
+import { FOOTER_TYPES, Footer } from "@Shared/Footer/Footer";
+import C2paData from "components/NavItems/tools/C2pa/C2pa";
 
-import AnalysisIcon from "../components/NavBar/images/SVG/Video/Video_analysis.svg";
-import KeyframesIcon from "../components/NavBar/images/SVG/Video/Keyframes.svg";
-import ThumbnailsIcon from "../components/NavBar/images/SVG/Video/Thumbnails.svg";
-import VideoRightsIcon from "../components/NavBar/images/SVG/Video/Video_rights.svg";
-
-import MetadataIcon from "../components/NavBar/images/SVG/Image/Metadata.svg";
+import CsvSnaIcon from "../components/NavBar/images/SVG/DataAnalysis/CSV_SNA.svg";
+import TwitterSnaIcon from "../components/NavBar/images/SVG/DataAnalysis/Twitter_sna.svg";
+import C2paIcon from "../components/NavBar/images/SVG/Image/C2pa.svg";
 import DeepfakeIcon from "../components/NavBar/images/SVG/Image/Deepfake.svg";
+import ForensicIcon from "../components/NavBar/images/SVG/Image/Forensic.svg";
+import GeolocationIcon from "../components/NavBar/images/SVG/Image/Geolocation.svg";
+import GifIcon from "../components/NavBar/images/SVG/Image/Gif.svg";
 import ImageAnalysisIcon from "../components/NavBar/images/SVG/Image/Image_analysis.svg";
 import MagnifierIcon from "../components/NavBar/images/SVG/Image/Magnifier.svg";
-import ForensicIcon from "../components/NavBar/images/SVG/Image/Forensic.svg";
+import MetadataIcon from "../components/NavBar/images/SVG/Image/Metadata.svg";
 import OcrIcon from "../components/NavBar/images/SVG/Image/OCR.svg";
-import GifIcon from "../components/NavBar/images/SVG/Image/Gif.svg";
-import GeolocationIcon from "../components/NavBar/images/SVG/Image/Geolocation.svg";
-import C2paIcon from "../components/NavBar/images/SVG/Image/C2pa.svg";
-
-import TwitterSearchIcon from "../components/NavBar/images/SVG/Search/Twitter_search.svg";
-import CovidSearchIcon from "../components/NavBar/images/SVG/Search/Covid19.svg";
-import XnetworkIcon from "../components/NavBar/images/SVG/Search/Xnetwork.svg";
-
-import TwitterSnaIcon from "../components/NavBar/images/SVG/DataAnalysis/Twitter_sna.svg";
-import CsvSnaIcon from "../components/NavBar/images/SVG/DataAnalysis/CSV_SNA.svg";
 import AboutIcon from "../components/NavBar/images/SVG/Navbar/About.svg";
+import ToolsIcon from "../components/NavBar/images/SVG/Navbar/Tools.svg";
+import CovidSearchIcon from "../components/NavBar/images/SVG/Search/Covid19.svg";
+import TwitterSearchIcon from "../components/NavBar/images/SVG/Search/Twitter_search.svg";
+import XnetworkIcon from "../components/NavBar/images/SVG/Search/Xnetwork.svg";
+import KeyframesIcon from "../components/NavBar/images/SVG/Video/Keyframes.svg";
+import ThumbnailsIcon from "../components/NavBar/images/SVG/Video/Thumbnails.svg";
+import AnalysisIcon from "../components/NavBar/images/SVG/Video/Video_analysis.svg";
+import VideoRightsIcon from "../components/NavBar/images/SVG/Video/Video_rights.svg";
+import About from "../components/NavItems/About/About";
 import ToolsMenu from "../components/NavItems/tools/Alltools/ToolsMenu";
 import Analysis from "../components/NavItems/tools/Analysis/Analysis";
-import { Footer, FOOTER_TYPES } from "@Shared/Footer/Footer";
-import Keyframes from "../components/NavItems/tools/Keyframes/Keyframes";
-import Thumbnails from "../components/NavItems/tools/Thumbnails/Thumbnails";
-import VideoRights from "../components/NavItems/tools/VideoRights/VideoRights";
-import Metadata from "../components/NavItems/tools/Metadata/Metadata";
-import DeepfakeVideo from "../components/NavItems/tools/Deepfake/DeepfakeVideo";
 import AnalysisImg from "../components/NavItems/tools/Analysis_images/Analysis";
-import Magnifier from "../components/NavItems/tools/Magnifier/Magnifier";
-import Forensic from "../components/NavItems/tools/Forensic/Forensic";
-import OCR from "../components/NavItems/tools/OCR/OCR";
-import CheckGif from "../components/NavItems/tools/Gif/CheckGif";
-import SyntheticImageDetection from "../components/NavItems/tools/SyntheticImageDetection";
-import DeepfakeImage from "../components/NavItems/tools/Deepfake/DeepfakeImage";
-import Geolocation from "../components/NavItems/tools/Geolocation/Geolocation";
-import Loccus from "../components/NavItems/tools/Loccus";
-import TwitterAdvancedSearch from "../components/NavItems/tools/TwitterAdvancedSearch/TwitterAdvancedSearch";
-import SemanticSearch from "../components/NavItems/tools/SemanticSearch";
-import TwitterSna from "../components/NavItems/tools/TwitterSna/TwitterSna";
 import Archive from "../components/NavItems/tools/Archive";
-import About from "../components/NavItems/About/About";
+import DeepfakeImage from "../components/NavItems/tools/Deepfake/DeepfakeImage";
+import DeepfakeVideo from "../components/NavItems/tools/Deepfake/DeepfakeVideo";
+import Forensic from "../components/NavItems/tools/Forensic/Forensic";
+import Geolocation from "../components/NavItems/tools/Geolocation/Geolocation";
+import CheckGif from "../components/NavItems/tools/Gif/CheckGif";
+import Keyframes from "../components/NavItems/tools/Keyframes/Keyframes";
+import Loccus from "../components/NavItems/tools/Loccus";
+import Magnifier from "../components/NavItems/tools/Magnifier/Magnifier";
+import Metadata from "../components/NavItems/tools/Metadata/Metadata";
+import OCR from "../components/NavItems/tools/OCR/OCR";
+import SemanticSearch from "../components/NavItems/tools/SemanticSearch";
+import SyntheticImageDetection from "../components/NavItems/tools/SyntheticImageDetection";
+import Thumbnails from "../components/NavItems/tools/Thumbnails/Thumbnails";
+import TwitterAdvancedSearch from "../components/NavItems/tools/TwitterAdvancedSearch/TwitterAdvancedSearch";
+import TwitterSna from "../components/NavItems/tools/TwitterSna/TwitterSna";
+import VideoRights from "../components/NavItems/tools/VideoRights/VideoRights";
 import { ROLES } from "./roles";
-import C2paData from "components/NavItems/tools/C2pa/C2pa";
 
 /**
  * Represents the categories to which the tools belong

--- a/src/constants/topMenuItems.jsx
+++ b/src/constants/topMenuItems.jsx
@@ -1,19 +1,20 @@
 import React from "react";
-import { Box, SvgIcon } from "@mui/material";
-import ToolsIcon from "../components/NavBar/images/SVG/Navbar/Tools.svg";
-import Assistant from "../components/NavItems/Assistant/Assistant";
-import { Footer, FOOTER_TYPES } from "../components/Shared/Footer/Footer";
-import ClassRoom from "../components/NavItems/ClassRoom/ClassRoom";
-import About from "../components/NavItems/About/About";
-import Interactive from "../components/NavItems/Interactive/Interactive";
-import Tutorial from "../components/NavItems/tutorial/tutorial";
-import AssistantIcon from "../components/NavBar/images/SVG/Navbar/Assistant.svg";
 
-import ClassroomIcon from "../components/NavBar/images/SVG/Navbar/Classroom.svg";
-import InteractiveIcon from "../components/NavBar/images/SVG/Navbar/Interactive.svg";
+import Box from "@mui/material/Box";
+import SvgIcon from "@mui/material/SvgIcon";
 
 import AboutIcon from "../components/NavBar/images/SVG/Navbar/About.svg";
+import AssistantIcon from "../components/NavBar/images/SVG/Navbar/Assistant.svg";
+import ClassroomIcon from "../components/NavBar/images/SVG/Navbar/Classroom.svg";
 import GuideIcon from "../components/NavBar/images/SVG/Navbar/Guide.svg";
+import InteractiveIcon from "../components/NavBar/images/SVG/Navbar/Interactive.svg";
+import ToolsIcon from "../components/NavBar/images/SVG/Navbar/Tools.svg";
+import About from "../components/NavItems/About/About";
+import Assistant from "../components/NavItems/Assistant/Assistant";
+import ClassRoom from "../components/NavItems/ClassRoom/ClassRoom";
+import Interactive from "../components/NavItems/Interactive/Interactive";
+import Tutorial from "../components/NavItems/tutorial/tutorial";
+import { FOOTER_TYPES, Footer } from "../components/Shared/Footer/Footer";
 import { TOOLS_CATEGORIES } from "./tools";
 
 const ToolsSvgIcon = (props) => {

--- a/transform.js
+++ b/transform.js
@@ -1,0 +1,36 @@
+// Code from https://stackoverflow.com/questions/76572684/jscodeshift-to-convert-all-named-imports-to-default-import-mui-v5/77150908#77150908
+import type { FileInfo, API, Options } from 'jscodeshift';
+export default function transform(
+    file: FileInfo,
+    api: API,
+    options: Options,
+): string | undefined {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+
+    // Find all ImportDeclaration nodes
+    root.find(j.ImportDeclaration).forEach(path => {
+        // Ensure the import source is '@mui/material'
+        if (path.node.source.value === '@mui/material') {
+            // Ensure the import specifiers are ImportSpecifier nodes
+            if (path.node.specifiers.every(specifier => specifier.type === 'ImportSpecifier')) {
+                // Create new ImportDeclaration nodes for each ImportSpecifier
+                const newImports = path.node.specifiers.map(specifier => {
+                    // Ensure the imported element is an Identifier
+                    if (specifier.imported.type === 'Identifier') {
+                        // Create a new ImportDeclaration node
+                        return j.importDeclaration(
+                            [j.importDefaultSpecifier(j.identifier(specifier.imported.name))],
+                            j.literal(`@mui/material/${specifier.imported.name}`)
+                        );
+                    }
+                });
+
+                // Replace the original ImportDeclaration node with the new ones
+                path.replace(...newImports);
+            }
+        }
+    });
+
+    return root.toSource();
+}

--- a/transform.js
+++ b/transform.js
@@ -1,36 +1,200 @@
-// Code from https://stackoverflow.com/questions/76572684/jscodeshift-to-convert-all-named-imports-to-default-import-mui-v5/77150908#77150908
 import type { FileInfo, API, Options } from 'jscodeshift';
+
 export default function transform(
-    file: FileInfo,
-    api: API,
-    options: Options,
+  file: FileInfo,
+  api: API,
+  options: Options,
 ): string | undefined {
-    const j = api.jscodeshift;
-    const root = j(file.source);
+  const j = api.jscodeshift;
+  const root = j(file.source);
 
-    // Find all ImportDeclaration nodes
-    root.find(j.ImportDeclaration).forEach(path => {
-        // Ensure the import source is '@mui/material'
-        if (path.node.source.value === '@mui/material') {
-            // Ensure the import specifiers are ImportSpecifier nodes
-            if (path.node.specifiers.every(specifier => specifier.type === 'ImportSpecifier')) {
-                // Create new ImportDeclaration nodes for each ImportSpecifier
-                const newImports = path.node.specifiers.map(specifier => {
-                    // Ensure the imported element is an Identifier
-                    if (specifier.imported.type === 'Identifier') {
-                        // Create a new ImportDeclaration node
-                        return j.importDeclaration(
-                            [j.importDefaultSpecifier(j.identifier(specifier.imported.name))],
-                            j.literal(`@mui/material/${specifier.imported.name}`)
-                        );
-                    }
-                });
+  const muiModules = [
+    "Accordion",
+    "AccordionActions",
+    "AccordionDetails",
+    "AccordionSummary",
+    "Alert",
+    "AlertTitle",
+    "AppBar",
+    "Autocomplete",
+    "Avatar",
+    "AvatarGroup",
+    "Backdrop",
+    "Badge",
+    "BottomNavigation",
+    "BottomNavigationAction",
+    "Box",
+    "Breadcrumbs",
+    "Button",
+    "ButtonBase",
+    "ButtonGroup",
+    "ButtonGroupButtonContext",
+    "ButtonGroupContext",
+    "Card",
+    "CardActionArea",
+    "CardActions",
+    "CardContent",
+    "CardHeader",
+    "CardMedia",
+    "Checkbox",
+    "Chip",
+    "CircularProgress",
+    "ClickAwayListener",
+    "Collapse",
+    "Container",
+    "CssBaseline",
+    "CssVarsProvider",
+    "Dialog",
+    "DialogActions",
+    "DialogContent",
+    "DialogContentText",
+    "DialogTitle",
+    "Divider",
+    "Drawer",
+    "Experimental_CssVarsProvider",
+    "Fab",
+    "Fade",
+    "FilledInput",
+    "FormControl",
+    "FormControlLabel",
+    "FormGroup",
+    "FormHelperText",
+    "FormLabel",
+    "FormLabelRoot",
+    "GlobalStyles",
+    "Grid",
+    "Grid2",
+    "Grow",
+    "Hidden",
+    "Icon",
+    "IconButton",
+    "ImageList",
+    "ImageListItem",
+    "ImageListItemBar",
+    "Input",
+    "InputAdornment",
+    "InputBase",
+    "InputLabel",
+    "LinearProgress",
+    "Link",
+    "List",
+    "ListItem",
+    "ListItemAvatar",
+    "ListItemButton",
+    "ListItemIcon",
+    "ListItemSecondaryAction",
+    "ListItemText",
+    "ListSubheader",
+    "Menu",
+    "MenuItem",
+    "MenuList",
+    "MobileStepper",
+    "Modal",
+    "ModalManager",
+    "NativeSelect",
+    "NoSsr",
+    "OutlinedInput",
+    "Pagination",
+    "PaginationItem",
+    "Paper",
+    "Popover",
+    "PopoverPaper",
+    "PopoverRoot",
+    "Popper",
+    "Portal",
+    "Radio",
+    "RadioGroup",
+    "Rating",
+    "ScopedCssBaseline",
+    "Select",
+    "Skeleton",
+    "Slide",
+    "Slider",
+    "SliderMark",
+    "SliderMarkLabel",
+    "SliderRail",
+    "SliderRoot",
+    "SliderThumb",
+    "SliderTrack",
+    "SliderValueLabel",
+    "Snackbar",
+    "SnackbarContent",
+    "SpeedDial",
+    "SpeedDialAction",
+    "SpeedDialIcon",
+    "Stack",
+    "Step",
+    "StepButton",
+    "StepConnector",
+    "StepContent",
+    "StepContext",
+    "StepIcon",
+    "StepLabel",
+    "Stepper",
+    "StepperContext",
+    "StyledEngineProvider",
+    "SvgIcon",
+    "SwipeableDrawer",
+    "Switch",
+    "Tab",
+    "TabScrollButton",
+    "Table",
+    "TableBody",
+    "TableCell",
+    "TableContainer",
+    "TableFooter",
+    "TableHead",
+    "TablePagination",
+    "TableRow",
+    "TableSortLabel",
+    "Tabs",
+    "TextField",
+    "TextareaAutosize",
+    "ToggleButton",
+    "ToggleButtonGroup",
+    "Toolbar",
+    "Tooltip",
+    "Typography",
+    "Zoom"
+  ]
 
-                // Replace the original ImportDeclaration node with the new ones
-                path.replace(...newImports);
-            }
+  root.find(j.ImportDeclaration).forEach(path => {
+    if (path.node.source.value === '@mui/material') {
+      const specifiersToTransform = path.node.specifiers.filter(
+        specifier =>
+          specifier.type === 'ImportSpecifier' &&
+          specifier.imported.type === 'Identifier' &&
+          muiModules.includes(specifier.imported.name)
+      );
+
+      if (specifiersToTransform.length > 0) {
+        // Create new ImportDeclaration nodes for the specifiers to transform
+        const newImports = specifiersToTransform.map(specifier => {
+          return j.importDeclaration(
+            [j.importDefaultSpecifier(j.identifier(specifier.imported.name))],
+            j.literal(`@mui/material/${specifier.imported.name}`)
+          );
+        });
+
+        // Create a new ImportDeclaration node for the remaining specifiers like "styled", which must come from "@mui/material"
+        const remainingSpecifiers = path.node.specifiers.filter(
+          specifier => !specifiersToTransform.includes(specifier)
+        );
+        const newRemainingImport = j.importDeclaration(
+          remainingSpecifiers,
+          j.literal('@mui/material')
+        );
+
+        // Replace the original ImportDeclaration node with the new ones
+        if (remainingSpecifiers.length > 0) {
+          path.replace(...newImports, newRemainingImport);
         }
-    });
+        else {
+          path.replace(...newImports);
+        }
+      }
+    }
+  });
 
-    return root.toSource();
+  return root.toSource();
 }


### PR DESCRIPTION
 - Added `prettier-plugin-sort-imports` plugin to order the imports consistently
 - Added `jscodeshift` plugins to convert `import {Thing} from "@mui/material"` imports to `import Thing from "@mui/material/Thing"`
 - Made both of these part of the pre-commit
 - Ran them both on the Assistant files

If you would like, I can run the new transforms globally to prevent commit noise later on, or we can gradually shift to the new formatting as files get updated.