### PR TITLE
Jmafoster1/744 fix wrong language

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
@@ -38,7 +38,7 @@ export default function TextFooter({
             className={classes.toolTipIcon}
             onClick={() => setDisplayOrigLang(!displayOrigLang)}
           >
-            {getLanguageName(textLang) ?? textLang}
+            {getLanguageName(textLang, textLang) ?? textLang}
           </Typography>
         </Grid2>
 

--- a/src/components/NavItems/tools/SemanticSearch/SemanticSearchResults.jsx
+++ b/src/components/NavItems/tools/SemanticSearch/SemanticSearchResults.jsx
@@ -128,7 +128,10 @@ const SemanticSearchResults = (searchResults) => {
                     ) ?? null
                   }
                   website={resultItem.website}
-                  language={getLanguageName(resultItem.language)}
+                  language={getLanguageName(
+                    resultItem.language,
+                    resultItem.language,
+                  )}
                   similarityScore={resultItem.similarityScore}
                   articleUrl={resultItem.articleUrl}
                   domainUrl={resultItem.domainUrl}


### PR DESCRIPTION
Closes #744. The issue was that `getLanguageName` expects a language and a locale, but was only being given a language. I found the same thing in `SemanticSearchResults` too, so I also fixed that.