### PR TITLE
Jmafoster1/275 fix warning triangle

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -17,6 +17,7 @@ import LinearProgress from "@mui/material/LinearProgress";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
+import { WarningAmber } from "@mui/icons-material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
@@ -38,7 +39,6 @@ import {
 import AssistantImageResult from "./AssistantImageResult";
 import AssistantProcessUrlActions from "./AssistantProcessUrlActions";
 import AssistantVideoResult from "./AssistantVideoResult";
-import WarningAmber from "./AssistantWarnings";
 
 const AssistantMediaResult = () => {
   const classes = useMyStyles();


### PR DESCRIPTION
Closes https://github.com/GateNLP/we-verify-app-assistant/issues/275.
It seems that we define our own `WarningAmber` element and we were simply importing the wrong one in `AssistantMediaResult`!

>[!NOTE]
> It also does this on the live version, so maybe this should be patched in sooner than the next release if that's possible.