### PR TITLE
Assistant/0.85 fixes

### DIFF
--- a/src/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResults.jsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
+import Collapse from "@mui/material/Collapse";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 
@@ -21,6 +22,9 @@ import { TextFooterPrevFactChecks } from "../AssistantScrapeResults/TextFooter";
 
 const PreviousFactCheckResults = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");
+
+  // display states
+  const [expanded, setExpanded] = useState(true);
 
   // previous fact checks
   const prevFactChecksTitle = keyword("previous_fact_checks_title");
@@ -61,34 +65,42 @@ const PreviousFactCheckResults = () => {
       <AccordionDetails>
         {prevFactChecksDone && prevFactChecksResult.length > 0 && (
           <div>
-            {prevFactChecksResult.map((resultItem) => {
-              // date in correct format
-              const date = resultItem.published_at.slice(0, 10);
+            <Collapse in={expanded} collapsedSize={500}>
+              {prevFactChecksResult.map((resultItem) => {
+                // date in correct format
+                const date = resultItem.published_at.slice(0, 10);
 
-              return (
-                <ResultDisplayItem
-                  key={resultItem.id}
-                  id={resultItem.id}
-                  claim={resultItem.claim_en}
-                  title={resultItem.title_en}
-                  claimOriginalLanguage={resultItem.claim}
-                  titleOriginalLanguage={resultItem.title}
-                  rating={resultItem.rating}
-                  date={
-                    dayjs(date).format(globalLocaleData.longDateFormat("LL")) ??
-                    null
-                  }
-                  website={resultItem.website}
-                  language={getLanguageName(resultItem.source_language)}
-                  similarityScore={resultItem.score}
-                  articleUrl={resultItem.url}
-                  domainUrl={resultItem.source_name}
-                  imageUrl={resultItem.image_url}
-                />
-              );
-            })}
+                return (
+                  <ResultDisplayItem
+                    key={resultItem.id}
+                    id={resultItem.id}
+                    claim={resultItem.claim_en}
+                    title={resultItem.title_en}
+                    claimOriginalLanguage={resultItem.claim}
+                    titleOriginalLanguage={resultItem.title}
+                    rating={resultItem.rating}
+                    date={
+                      dayjs(date).format(
+                        globalLocaleData.longDateFormat("LL"),
+                      ) ?? null
+                    }
+                    website={resultItem.website}
+                    language={getLanguageName(resultItem.source_language)}
+                    similarityScore={resultItem.score}
+                    articleUrl={resultItem.url}
+                    domainUrl={resultItem.source_name}
+                    imageUrl={resultItem.image_url}
+                  />
+                );
+              })}
+            </Collapse>
 
-            <TextFooterPrevFactChecks navigate={navigate} keyword={keyword} />
+            <TextFooterPrevFactChecks
+              navigate={navigate}
+              keyword={keyword}
+              setExpanded={setExpanded}
+              expanded={expanded}
+            />
           </div>
         )}
       </AccordionDetails>

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
@@ -56,7 +56,7 @@ const SourceCredibilityDBKFDialog = (props) => {
       <Dialog onClose={handleClose} maxWidth={"lg"} open={open}>
         <DialogTitle>
           <Grid container>
-            <Grid container size={{ xs: 11 }} direction="row">
+            <Grid size={{ xs: 11 }}>
               <Typography variant="body1" component="div">
                 <Chip label={keyword(sourceType)} color={color} size="small" />{" "}
                 {keyword("source_cred_popup_header_domain")} {source}

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
@@ -28,7 +28,7 @@ const SourceCredibilityResult = (props) => {
             <ListItem key={key}>
               <ListItemText
                 primary={
-                  <Box sx={{ ml: 2 }}>
+                  <Box>
                     <Typography
                       variant={"body1"}
                       component={"div"}

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -324,12 +324,7 @@ const AssistantLinkResult = () => {
     <Card variant="outlined">
       <CardHeader
         className={classes.assistantCardHeader}
-        title={
-          <Typography variant={"h5"}>
-            {" "}
-            {keyword("extracted_urls_url_domain_analysis")}{" "}
-          </Typography>
-        }
+        title={keyword("extracted_urls_url_domain_analysis")}
         action={
           <Tooltip
             interactive={"true"}

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
@@ -94,12 +94,20 @@ const AssistantSCResults = () => {
           </Box>
 
           {/* expand button */}
-          <IconButton
-            className={classes.assistantIconRight}
-            onClick={() => dispatch(setAssuranceExpanded(!assuranceExpanded))}
+          <Box
+            sx={{
+              pr: 1,
+              pt: 1,
+            }}
           >
-            <ExpandMoreIcon color={"primary"} />
-          </IconButton>
+            <IconButton
+              className={classes.assistantIconRight}
+              onClick={() => dispatch(setAssuranceExpanded(!assuranceExpanded))}
+              sx={{ p: 1 }}
+            >
+              <ExpandMoreIcon color={"primary"} />
+            </IconButton>
+          </Box>
         </Grid>
 
         <Grid size={{ xs: 1 }}>

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -254,27 +254,53 @@ const AssistantTextResult = () => {
           >
             <Tab label={keyword("raw_text")} {...a11yProps(0)} />
             <Tab
-              label={newsFramingTitle}
+              label={
+                <div>
+                  {newsFramingTitle}
+                  {newsFramingLoading && <LinearProgress />}
+                </div>
+              }
               {...a11yProps(1)}
               disabled={newsFramingFail || newsFramingLoading}
             />
             <Tab
-              label={newsGenreTitle}
+              label={
+                <div>
+                  {newsGenreTitle}
+                  {newsGenreLoading && <LinearProgress />}
+                </div>
+              }
               {...a11yProps(2)}
               disabled={newsGenreFail || newsGenreLoading}
             />
             <Tab
-              label={persuasionTitle}
+              label={
+                <div>
+                  {persuasionTitle}
+                  {persuasionLoading && <LinearProgress />}
+                </div>
+              }
               {...a11yProps(3)}
               disabled={persuasionFail || persuasionLoading}
             />
             <Tab
-              label={subjectivityTitle}
+              label={
+                <div>
+                  {subjectivityTitle}
+                  {subjectivityLoading && <LinearProgress />}
+                </div>
+              }
               {...a11yProps(4)}
               disabled={subjectivityFail || subjectivityLoading}
             />
             <Tab
-              label={machineGeneratedTextTitle}
+              label={
+                <div>
+                  {machineGeneratedTextTitle}
+                  {(machineGeneratedTextChunksLoading ||
+                    machineGeneratedTextSentencesLoading) && <LinearProgress />}
+                </div>
+              }
               {...a11yProps(5)}
               disabled={
                 machineGeneratedTextChunksFail ||

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
@@ -74,12 +74,20 @@ const AssistantWarnings = () => {
               </Box>
             </Typography>
           </div>
-          <IconButton
-            className={classes.assistantIconRight}
-            onClick={() => dispatch(setWarningExpanded(!warningExpanded))}
+          <Box
+            sx={{
+              pr: 1,
+              pt: 1,
+            }}
           >
-            <ExpandMoreIcon color={"warning"} />
-          </IconButton>
+            <IconButton
+              className={classes.assistantIconRight}
+              onClick={() => dispatch(setWarningExpanded(!warningExpanded))}
+              sx={{ p: 1 }}
+            >
+              <ExpandMoreIcon color={"warning"} />
+            </IconButton>
+          </Box>
         </Grid>
         <Grid size={{ xs: 12 }}>
           <Collapse

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -24,7 +24,6 @@ export default function TextFooter({
   textLang,
   expandMinimiseText,
   text,
-  displayExpander,
   setExpanded,
   expanded,
 }) {
@@ -96,7 +95,6 @@ export default function TextFooter({
           <ExpandMinimise
             classes={classes}
             expandMinimiseText={expandMinimiseText}
-            displayExpander={displayExpander}
             setExpanded={setExpanded}
             expanded={expanded}
           />
@@ -106,15 +104,18 @@ export default function TextFooter({
   );
 }
 
-export function TextFooterPrevFactChecks({ navigate, keyword }) {
+export function TextFooterPrevFactChecks({
+  navigate,
+  keyword,
+  setExpanded,
+  expanded,
+}) {
   const handleClick = (path) => {
     // instead need to set parameter then load text in SemanticSearch/index.jsx
     navigate("/app/" + path + "/assistantText");
   };
   const classes = useMyStyles();
   const expandMinimiseText = keyword("expand_minimise_text");
-  const [displayExpander, setDisplayExpander] = useState(true);
-  const [expanded, setExpanded] = useState(false);
 
   return (
     <Box>
@@ -147,7 +148,6 @@ export function TextFooterPrevFactChecks({ navigate, keyword }) {
           <ExpandMinimise
             classes={classes}
             expandMinimiseText={expandMinimiseText}
-            displayExpander={displayExpander}
             setExpanded={setExpanded}
             expanded={expanded}
           />


### PR DESCRIPTION
More fixes:
- removed padding in source credibility/URL domain analysis results
- spotted and changed inconsistency in Extracted URLs title
- changed padding for misaligned ripple effect (Warnings and URL Domain Analysis CardHeaders)
- added LinearProgress to credibility signals when loading (an alternative would be to have the icon for each tab be a CircularProgress)

![image - 2025-05-12T210858 567](https://github.com/user-attachments/assets/947017b2-221d-4832-9011-f116bdf8c369)
