### PR TITLE
Assistant/fixed threshold being ignored

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -152,7 +152,9 @@ export default function AssistantTextClassification({
           sentenceIndices[i].score >= configs.importanceThresholdLow
         ) {
           filteredSentences.push(sentenceIndices[i]);
-        } else {
+        } else if (
+          credibilitySignal === keyword("machine_generated_text_title")
+        ) {
           filteredSentences.push(sentenceIndices[i]);
         }
       }
@@ -163,7 +165,9 @@ export default function AssistantTextClassification({
         classification[label][0].score >= configs.confidenceThresholdLow
       ) {
         filteredCategories[label] = classification[label];
-      } else {
+      } else if (
+        credibilitySignal === keyword("machine_generated_text_title")
+      ) {
         filteredCategories[label] = classification[label];
       }
     }


### PR DESCRIPTION
The threshold for some of the credibility signals is being ignored, meaning sentences ad categories with scores below 0.8 (current set threshold) are being displayed to the user.
- fixed the if statement to allow filtering sentences and categories above 0.8 for topic, genre, persuasion and subjectivity
- for machien generated text, all the sentences and categories are included as all are required to be highlighted
- having tried a few links, it's not a huge difference but given some people's comments in the evaluation session yesterday being there's a lot of information, setting the threshold would keep the results refined 