### PR TITLE
Removed background and scrollbar from video grid

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -269,6 +269,7 @@ const AssistantMediaResult = () => {
                     handleClick={(vidLink) => {
                       submitMediaToProcess(vidLink);
                     }}
+                    style={{ overflowY: "visible" }}
                   />
                 </AccordionDetails>
               </Accordion>

--- a/src/components/Shared/VideoGridList/VideoGridList.jsx
+++ b/src/components/Shared/VideoGridList/VideoGridList.jsx
@@ -15,7 +15,7 @@ const styles = (theme) => ({
     display: "flex",
     flexWrap: "wrap",
     overflow: "hidden",
-    backgroundColor: theme.palette.background.paper,
+    // backgroundColor: theme.palette.background.paper,
   },
   imageList: {
     width: "100%",


### PR DESCRIPTION
I noticed that the media videos had a hardcoded white background, so looked bad in dark mode. I removed this, and also the `overflow-y` scroll bar.
![image](https://github.com/user-attachments/assets/fd8f6861-c661-4a60-8fe2-e84815455871)

Now it looks like
![image](https://github.com/user-attachments/assets/f47d43c5-3434-43c6-b7fe-f669941b89ae)
