### PR TITLE
best practice for tidying imports

### DIFF
--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -12,25 +12,25 @@ import Typography from "@mui/material/Typography";
 
 import { Close } from "@mui/icons-material";
 
+import AssistantCheckStatus from "@/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus";
+import AssistantNEResult from "@/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult";
+import AssistantCommentResult from "@/components/NavItems/Assistant/AssistantScrapeResults/AssistantCommentResult";
+import AssistantLinkResult from "@/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult";
+import AssistantMediaResult from "@/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult";
+import AssistantSCResults from "@/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults";
+import AssistantTextResult from "@/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult";
+import AssistantWarnings from "@/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import {
   cleanAssistantState,
   setUrlMode,
   submitInputUrl,
 } from "@/redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { setError } from "redux/reducers/errorReducer";
+import { setError } from "@/redux/reducers/errorReducer";
 
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
-import AssistantCheckStatus from "./AssistantCheckResults/AssistantCheckStatus";
-import AssistantNEResult from "./AssistantCheckResults/AssistantNEResult";
 import AssistantFileSelected from "./AssistantFileSelected";
 import AssistantIntroduction from "./AssistantIntroduction";
-import AssistantCommentResult from "./AssistantScrapeResults/AssistantCommentResult";
-import AssistantLinkResult from "./AssistantScrapeResults/AssistantLinkResult";
-import AssistantMediaResult from "./AssistantScrapeResults/AssistantMediaResult";
-import AssistantSCResults from "./AssistantScrapeResults/AssistantSCResults";
-import AssistantTextResult from "./AssistantScrapeResults/AssistantTextResult";
-import AssistantWarnings from "./AssistantScrapeResults/AssistantWarnings";
 import AssistantUrlSelected from "./AssistantUrlSelected";
 
 const Assistant = () => {

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantCheckStatus.jsx
@@ -12,10 +12,10 @@ import Typography from "@mui/material/Typography";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import { setStateExpanded } from "@/redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   KNOWN_LINKS,
   KNOWN_LINK_PATTERNS,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/AssistantNEResult.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
-//import ReactWordcloud from "react-wordcloud";
 import { TagCloud } from "react-tagcloud";
 
 import Button from "@mui/material/Button";
@@ -16,11 +15,11 @@ import Tooltip from "@mui/material/Tooltip";
 
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import "tippy.js/animations/scale.css";
 import "tippy.js/dist/tippy.css";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransHtmlDoubleLineBreak,
   TransNamedEntityRecogniserLink,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/DbkfMediaResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/DbkfMediaResults.jsx
@@ -16,7 +16,7 @@ import { DuoOutlined } from "@mui/icons-material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ImageIconOutlined from "@mui/icons-material/Image";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
 
 const DbkfMediaResults = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");

--- a/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults.jsx
@@ -16,7 +16,7 @@ import Typography from "@mui/material/Typography";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import TextFieldsIcon from "@mui/icons-material/TextFields";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
 
 const DbkfTextResults = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");

--- a/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityDBKFDialog.jsx
@@ -23,9 +23,9 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransHtmlDoubleLineBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResults.jsx
@@ -11,9 +11,9 @@ import Typography from "@mui/material/Typography";
 
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
-import ResultDisplayItem from "components/NavItems/tools/SemanticSearch/components/ResultDisplayItem";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { getLanguageName } from "components/Shared/Utils/languageUtils";
+import ResultDisplayItem from "@/components/NavItems/tools/SemanticSearch/components/ResultDisplayItem";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import { getLanguageName } from "@/components/Shared/Utils/languageUtils";
 import dayjs from "dayjs";
 import LocaleData from "dayjs/plugin/localeData";
 import localizedFormat from "dayjs/plugin/localizedFormat";

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityDBKFDialog.jsx
@@ -17,9 +17,9 @@ import CloseIcon from "@mui/icons-material/Close";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import ListAltOutlinedIcon from "@mui/icons-material/ListAltOutlined";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransHtmlDoubleLineBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult.jsx
@@ -7,7 +7,7 @@ import ListItemSecondaryAction from "@mui/material/ListItemSecondaryAction";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
 
 import SourceCredibilityDBKFDialog from "./SourceCredibilityDBKFDialog";
 import { getUrlTypeFromCredScope } from "./assistantUtils";

--- a/src/components/NavItems/Assistant/AssistantFileSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantFileSelected.jsx
@@ -13,9 +13,9 @@ import ListItemAvatar from "@mui/material/ListItemAvatar";
 import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 import {
   CONTENT_TYPE,
   KNOWN_LINKS,

--- a/src/components/NavItems/Assistant/AssistantIntroduction.jsx
+++ b/src/components/NavItems/Assistant/AssistantIntroduction.jsx
@@ -14,15 +14,15 @@ import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import LinkIcon from "@mui/icons-material/Link";
 
+import AssistantIcon from "@/components/NavBar/images/navbar/assistant-icon-primary.svg";
+import HeaderTool from "@/components/Shared/HeaderTool/HeaderTool";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import {
   setImageVideoSelected,
   setUrlMode,
 } from "@/redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import AssistantIcon from "../../NavBar/images/navbar/assistant-icon-primary.svg";
-import HeaderTool from "../../Shared/HeaderTool/HeaderTool";
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransHtmlDoubleLineBreak,
   TransSupportedToolsLink,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCommentResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCommentResult.jsx
@@ -26,12 +26,12 @@ import { SubdirectoryArrowRight } from "@mui/icons-material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { TextCopy } from "components/Shared/Utils/TextCopy";
-import { Translate } from "components/Shared/Utils/Translate";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
+import { TextCopy } from "@/components/Shared/Utils/TextCopy";
+import { Translate } from "@/components/Shared/Utils/Translate";
 import moment from "moment/moment";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransHtmlDoubleLineBreak,
   TransMultilingualStanceLink,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantCredibilitySignals.jsx
@@ -20,21 +20,21 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import Remove from "@mui/icons-material/Remove";
 
+import GaugeChartResult from "@/components/Shared/GaugeChartResults/GaugeChartResult.jsx";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
+import ResultDisplayItem from "@/components/tools/SemanticSearch/components/ResultDisplayItem.jsx";
 import { ROLES } from "@/constants/roles";
 import { getLanguageName } from "@Shared/Utils/languageUtils";
-import GaugeChartResult from "components/Shared/GaugeChartResults/GaugeChartResult.jsx";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 import dayjs from "dayjs";
 import LocaleData from "dayjs/plugin/localeData";
 import localizedFormat from "dayjs/plugin/localizedFormat";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransCredibilitySignalsLink,
   TransHtmlDoubleLineBreak,
   TransHtmlSingleLineBreak,
 } from "../TransComponents";
-import ResultDisplayItem from "./../../tools/SemanticSearch/components/ResultDisplayItem.jsx";
 import TextFooterPrevFactChecks from "./TextFooter.jsx";
 
 const getExpandIcon = (

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantImageResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantImageResult.jsx
@@ -12,9 +12,8 @@ import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 
 const AssistantImageResult = () => {
   const classes = useMyStyles();

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantLinkResult.jsx
@@ -15,12 +15,12 @@ import Typography from "@mui/material/Typography";
 
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
+import ExtractedSourceCredibilityResult from "@/components/NavItems/Assistant/AssistantCheckResults/ExtractedSourceCredibilityResult";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import { TextCopy } from "@Shared/Utils/TextCopy";
 import { DataGrid, getGridSingleSelectOperators } from "@mui/x-data-grid";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import ExtractedSourceCredibilityResult from "../AssistantCheckResults/ExtractedSourceCredibilityResult";
 import {
   TransHtmlDoubleLineBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantMediaResult.jsx
@@ -21,16 +21,16 @@ import { WarningAmber } from "@mui/icons-material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
+import ImageGridList from "@/components/Shared/ImageGridList/ImageGridList";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
+import VideoGridList from "@/components/Shared/VideoGridList/VideoGridList";
 import {
   setProcessUrl,
   setStateExpanded,
   setWarningExpanded,
 } from "@/redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import ImageGridList from "../../../Shared/ImageGridList/ImageGridList";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import VideoGridList from "../../../Shared/VideoGridList/VideoGridList";
 import { CONTENT_TYPE } from "../AssistantRuleBook";
 import {
   TransHtmlDoubleLineBreak,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantProcessUrlActions.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantProcessUrlActions.jsx
@@ -14,16 +14,16 @@ import ListItemText from "@mui/material/ListItemText";
 import Typography from "@mui/material/Typography";
 
 import {
+  resetDeepfake as resetDeepfakeVideo,
+  setDeepfakeUrlVideo,
+} from "@//redux/actions/tools/deepfakeVideoActions";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
+import {
   resetSyntheticImageDetectionImage,
   setSyntheticImageDetectionUrl,
 } from "@/redux/actions/tools/syntheticImageDetectionActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import {
-  resetDeepfake as resetDeepfakeVideo,
-  setDeepfakeUrlVideo,
-} from "../../../../redux/actions/tools/deepfakeVideoActions";
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import { KNOWN_LINKS } from "../AssistantRuleBook";
 
 const AssistantProcessUrlActions = () => {

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantSCResults.jsx
@@ -18,11 +18,11 @@ import FindInPageIcon from "@mui/icons-material/FindInPage";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 import SentimentSatisfied from "@mui/icons-material/SentimentSatisfied";
 
+import SourceCredibilityResult from "@/components/NavItems/Assistant/AssistantCheckResults/SourceCredibilityResult";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import { setAssuranceExpanded } from "@/redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import SourceCredibilityResult from "../AssistantCheckResults/SourceCredibilityResult";
 import {
   TransHtmlDoubleLineBreak,
   TransSourceCredibilityTooltip,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -12,18 +12,17 @@ import Grid from "@mui/material/Grid";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
-import Stack from "@mui/material/Stack";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
-import GaugeChartModalExplanation from "components/Shared/GaugeChartResults/GaugeChartModalExplanation";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import GaugeChartModalExplanation from "@/components/Shared/GaugeChartResults/GaugeChartModalExplanation";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import ColourGradientTooltipContent from "./ColourGradientTooltipContent";
 import "./assistantTextResultStyle.css";
 import {
@@ -168,7 +167,10 @@ export default function AssistantTextClassification({
   if (Object.keys(filteredCategories).length === 0) {
     filteredSentences = [];
   }
-  if (credibilitySignal === keyword("subjectivity_title") && Object.keys(filteredSentences).length === 0) {
+  if (
+    credibilitySignal === keyword("subjectivity_title") &&
+    Object.keys(filteredSentences).length === 0
+  ) {
     filteredCategories = [];
   }
 

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -16,10 +16,10 @@ import Typography from "@mui/material/Typography";
 import { WarningAmber } from "@mui/icons-material";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import { setWarningExpanded } from "@/redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import {
   TransCredibilitySignalsLink,
   TransHtmlDoubleLineBreak,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextSpanClassification.jsx
@@ -15,11 +15,11 @@ import Typography from "@mui/material/Typography";
 
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import ColourGradientTooltipContent from "./ColourGradientTooltipContent";
 import {
   interpRgb,

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantVideoResult.jsx
@@ -14,9 +14,9 @@ import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
 import ImageIcon from "@mui/icons-material/Image";
 
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
 import { KNOWN_LINKS } from "../AssistantRuleBook";
 
 const AssistantVideoResult = () => {

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantWarnings.jsx
@@ -12,14 +12,13 @@ import Typography from "@mui/material/Typography";
 import { WarningAmber } from "@mui/icons-material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
+import DbkfMediaResults from "@/components/NavItems/Assistant/AssistantCheckResults/DbkfMediaResults";
+import DbkfTextResults from "@/components/NavItems/Assistant/AssistantCheckResults/DbkfTextResults";
+import PreviousFactCheckResults from "@/components/NavItems/Assistant/AssistantCheckResults/PreviousFactCheckResults";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
+import { ROLES } from "@/constants/roles";
 import { setWarningExpanded } from "@/redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
-import { ROLES } from "constants/roles";
-
-import useMyStyles from "../../../Shared/MaterialUiStyles/useMyStyles";
-import DbkfMediaResults from "../AssistantCheckResults/DbkfMediaResults";
-import DbkfTextResults from "../AssistantCheckResults/DbkfTextResults";
-import PreviousFactCheckResults from "../AssistantCheckResults/PreviousFactCheckResults";
 
 const AssistantWarnings = () => {
   const keyword = i18nLoadNamespace("components/NavItems/tools/Assistant");

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
@@ -11,11 +11,11 @@ import Typography from "@mui/material/Typography";
 
 import { ExpandLessOutlined, ExpandMoreOutlined } from "@mui/icons-material";
 
+import { i18nLoadNamespace } from "@Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "@Shared/MaterialUiStyles/useMyStyles";
 import { TextCopy } from "@Shared/Utils/TextCopy";
 import { Translate } from "@Shared/Utils/Translate";
 import { getLanguageName } from "@Shared/Utils/languageUtils";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
 export default function TextFooter({
   classes,

--- a/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
+++ b/src/components/NavItems/Assistant/AssistantUrlSelected.jsx
@@ -19,13 +19,13 @@ import ArchiveOutlinedIcon from "@mui/icons-material/ArchiveOutlined";
 import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
 import { useTrackEvent } from "@/Hooks/useAnalytics";
+import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
+import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import {
   cleanAssistantState,
   submitInputUrl,
 } from "@/redux/actions/tools/assistantActions";
-import { i18nLoadNamespace } from "components/Shared/Languages/i18nLoadNamespace";
 
-import useMyStyles from "../../Shared/MaterialUiStyles/useMyStyles";
 import { KNOWN_LINKS } from "./AssistantRuleBook";
 import {
   TransHtmlDoubleLineBreak,


### PR DESCRIPTION
Using best practices for tidying up the imports in the Assistant files: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md

// 1. React imports first

// 2. Third-party libraries

// 3. Absolute imports (your app code)

// 4. Relative imports (your app code)

// 5. CSS imports