### PR TITLE
Fixed detected language display in text footer

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/TextFooter.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useSelector } from "react-redux";
 
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -28,6 +29,7 @@ export default function TextFooter({
   expanded,
 }) {
   const keyword = i18nLoadNamespace("components/Shared/utils");
+  const locale = useSelector((state) => state.language);
   return (
     <Box>
       <Divider />
@@ -47,7 +49,7 @@ export default function TextFooter({
               display: "inline",
             }}
           >
-            {getLanguageName(textLang, textLang) ?? textLang}
+            {getLanguageName(textLang, locale) ?? textLang}
           </Typography>
         </Grid>
 

--- a/src/components/Shared/Utils/languageUtils.jsx
+++ b/src/components/Shared/Utils/languageUtils.jsx
@@ -9,9 +9,9 @@ export const getLanguageName = (language, locale) => {
     typeof LanguageDictionary[language][locale] !== "string"
   ) {
     //TODO: Error handling
-    // console.error(
-    //   `Error: the language code ${language} is not ISO-639-1 compatible`,
-    // );
+    console.error(
+      `Error: the language code ${language}-${locale} is not ISO-639-1 compatible`,
+    );
     return LanguageDictionary["en"]["en"];
   }
   return LanguageDictionary[language][locale];


### PR DESCRIPTION
Closes https://github.com/GateNLP/we-verify-app-assistant/issues/323.

Now showing the detected language in the correct locale.