### PR TITLE
Assistant/Extracted URLs in alphabetical order

### DIFF
--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -1225,10 +1225,10 @@ const sortSourceCredibilityLinks = (
 
   let extractedLinks = [];
   extractedLinks = extractedLinks.concat(
-    cautionLinks,
-    mixedLinks,
-    positiveLinks,
-    unlabelledLinks,
+    cautionLinks.sort(),
+    mixedLinks.sort(),
+    positiveLinks.sort(),
+    unlabelledLinks.sort(),
   );
 
   return extractedLinks;


### PR DESCRIPTION
Alphabetically sort groups of extracted URLs so user sees same order each time for same submitted URL
- user currently sees a different order for the same submitted URL