### PR TITLE
Chunking entities in batches of 25 when calling dbpedia linking

### DIFF
--- a/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
+++ b/src/components/NavItems/Assistant/AssistantApiHandlers/useAssistantApi.jsx
@@ -81,18 +81,27 @@ export default function assistantApiCalls() {
           link: entity.link.value,
         };
       }
-      const dbQuery = `
-      SELECT ?iri ?abstract (GROUP_CONCAT(DISTINCT ?type; SEPARATOR = ",") AS ?schemaTypes)
-      WHERE {
-        VALUES ?iri { ${Object.keys(mapping).join(" ")} }
-        ?iri rdfs:comment ?abstract .
-        ?iri rdf:type ?type .
-        FILTER (lang(?abstract) = "${lang}")
-      }`;
-      const dbpediaResult = await axios.get(
-        `https://dbpedia.org/sparql?query=${encodeURIComponent(dbQuery)}&format=application%2Fsparql-results%2Bjson&timeout=30000&signal_void=on&signal_unconnected=on`,
-      );
-      for (const entity of dbpediaResult.data.results.bindings) {
+      const iris = Object.keys(mapping);
+      let dbpediaResultBindings = [];
+      const chunkSize = 25;
+      for (let i = 0; i < iris.length; i += chunkSize) {
+        const chunk = iris.slice(i, i + chunkSize);
+        const dbQuery = `
+          SELECT ?iri ?abstract (GROUP_CONCAT(DISTINCT ?type; SEPARATOR = ",") AS ?schemaTypes)
+          WHERE {
+            VALUES ?iri { ${chunk.join(" ")} }
+            ?iri rdfs:comment ?abstract .
+            ?iri rdf:type ?type .
+            FILTER (lang(?abstract) = "${lang}")
+          }`;
+        const dbpediaResult = await axios.get(
+          `https://dbpedia.org/sparql?query=${encodeURIComponent(dbQuery)}&format=application%2Fsparql-results%2Bjson&timeout=30000&signal_void=on&signal_unconnected=on`,
+        );
+        dbpediaResultBindings = dbpediaResultBindings.concat(
+          dbpediaResult.data.results.bindings,
+        );
+      }
+      for (const entity of dbpediaResultBindings) {
         mapping["<" + entity.iri.value + ">"]["abstract"] =
           entity.abstract.value;
         mapping["<" + entity.iri.value + ">"]["schemaTypes"] =


### PR DESCRIPTION
The dbpedia linking query seems to have a limit of 25 entities, after which it will timeout (without error) and return a partial result. This PR chunks named entities in batches of 25 for sending the dbpedia linking call so that this doesn't happen. I've checked it against [this article](https://www.breitbart.com/europe/2024/02/12/german-government-expects-10-million-migrants-to-flee-ukraine-if-russia-wins-war-report/) which has 27 named entities and it seems to work in reasonable time.