### PR TITLE
assistant/Youtube comments disabled

### DIFF
--- a/src/components/NavItems/Assistant/Assistant.jsx
+++ b/src/components/NavItems/Assistant/Assistant.jsx
@@ -269,7 +269,7 @@ const Assistant = () => {
               ) : null}
 
               {/* YouTube comments if video */}
-              {collectedComments ? (
+              {collectedComments.length > 0 ? (
                 <Grid size={12}>
                   <AssistantCommentResult
                     collectedComments={collectedComments}

--- a/src/redux/sagas/assistantSaga.jsx
+++ b/src/redux/sagas/assistantSaga.jsx
@@ -802,16 +802,17 @@ function* handleMultilingualStanceCall(action) {
   try {
     const inputUrl = yield select((state) => state.assistant.inputUrl); //action.payload.inputUrl;
     const urlType = matchPattern(inputUrl, KNOWN_LINK_PATTERNS);
+    const collectedComments = yield select(
+      (state) => state.assistant.collectedComments,
+    );
 
-    // only run stance classifier for youtube
+    // only run stance classifier for youtube if comments exist
     if (
-      urlType === KNOWN_LINKS.YOUTUBE ||
-      urlType === KNOWN_LINKS.YOUTUBESHORTS
+      (urlType === KNOWN_LINKS.YOUTUBE ||
+        urlType === KNOWN_LINKS.YOUTUBESHORTS) &&
+      collectedComments.length > 0
     ) {
       yield put(setMultilingualStanceDetails(null, true, false, false));
-      const collectedComments = yield select(
-        (state) => state.assistant.collectedComments,
-      );
 
       function createCommentArray(
         comments,


### PR DESCRIPTION
When a YouTube video has disabled comments or is a livestream, the Assistant shows an error and doesn't show the video. 
- after backend PR (https://github.com/GateNLP/we-verify-app-assistant/pull/331) it shows the video but with an empty comment box (loading bar still visible)
- this frontend PR fixes it to show the video without any comment box.


URL without comments: https://www.youtube.com/watch?v=jfKfPfyJRdk
<img width="1086" height="777" alt="chrome-extension___kpbecamjjhhfhbaopkmjpolhgnldohgb_popup html (8)" src="https://github.com/user-attachments/assets/fd618ccd-0be5-44e8-b987-6588575bf399" />

