### PR TITLE
dbkfTextMatch now pulls from state

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextResult.jsx
@@ -45,7 +45,7 @@ const AssistantTextResult = () => {
   const [textHtmlOutput, setTextHtmlOutput] = useState(null);
 
   // third party check states
-  const dbkfTextMatch = null; //useSelector((state) => state.assistant.dbkfTextMatch);
+  const dbkfTextMatch = useSelector((state) => state.assistant.dbkfTextMatch);
   const mtLoading = useSelector((state) => state.assistant.mtLoading);
   const dbkfTextMatchLoading = useSelector(
     (state) => state.assistant.dbkfTextMatchLoading,
@@ -209,28 +209,30 @@ const AssistantTextResult = () => {
                 />
               </Tooltip>
             </div>
-            <Tooltip
-              interactive={"true"}
-              title={
-                <>
-                  <Trans
-                    t={keyword}
-                    i18nKey="text_tooltip"
-                    components={{
-                      b: <b />,
-                      ul: <ul />,
-                      li: <li />,
-                    }}
-                  />
-                  <TransSupportedToolsLink keyword={keyword} />
-                  <TransHtmlDoubleLineBreak keyword={keyword} />
-                  <TransCredibilitySignalsLink keyword={keyword} />
-                </>
-              }
-              classes={{ tooltip: classes.assistantTooltip }}
-            >
-              <HelpOutlineOutlinedIcon className={classes.toolTipIcon} />
-            </Tooltip>
+            <div>
+              <Tooltip
+                interactive={"true"}
+                title={
+                  <>
+                    <Trans
+                      t={keyword}
+                      i18nKey="text_tooltip"
+                      components={{
+                        b: <b />,
+                        ul: <ul />,
+                        li: <li />,
+                      }}
+                    />
+                    <TransSupportedToolsLink keyword={keyword} />
+                    <TransHtmlDoubleLineBreak keyword={keyword} />
+                    <TransCredibilitySignalsLink keyword={keyword} />
+                  </>
+                }
+                classes={{ tooltip: classes.assistantTooltip }}
+              >
+                <HelpOutlineOutlinedIcon className={classes.toolTipIcon} />
+              </Tooltip>
+            </div>
           </div>
         }
       />


### PR DESCRIPTION
Relates to https://github.com/GateNLP/we-verify-app-assistant/issues/321#issuecomment-3174691259. For some reason `dbkfTextMatch` had been hardcoded to null. This PR puts it back, and also aligns the little warning triangle with the tooltip by wrapping it in a `div`.