### PR TITLE
assistant/fix missing genre

### DIFF
--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -153,8 +153,11 @@ export default function AssistantTextClassification({
         }
       }
     } else {
-      //Filter categories above confidenceThreshold unless machine generated text
-      if (credibilitySignal === keyword("machine_generated_text_title")) {
+      //Filter categories above confidenceThreshold unless machine generated text or news genre
+      if (
+        credibilitySignal === keyword("machine_generated_text_title") ||
+        credibilitySignal === keyword("news_genre_title")
+      ) {
         filteredCategories[label] = classification[label];
       } else if (
         classification[label][0].score >= configs.confidenceThresholdLow


### PR DESCRIPTION
If news genre is below the threshold, then blank results are shown. This fix ignores the threshold so there will always be a result.

- URL: https://www.snopes.com/fact-check/elvis-danny-sullivan-story/
<img width="1086" height="639" alt="chrome-extension___mhccpoafgdgbhnjfhkcmgknndkeenfhe_popup html" src="https://github.com/user-attachments/assets/063d479b-1429-4908-9acd-964f2d73593f" />
