### PR TITLE
Assistant/fix gaugechart import path

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,8 +3,9 @@
     "baseUrl": "./src",
     "paths": {
       "@/*": [
-        "src/*"
-      ]
+        "src/*"],
+      "@Shared/*": ["components/Shared/*"],
+      "@workers/*": ["workers/*"],
     },
     "checkJs": false,
     "jsx": "react"

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -20,7 +20,6 @@ import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
 import {
   ThresholdSlider,
-  // createGaugeExplanation,
   createGaugeChart,
   getMgtColours,
   getSubjectivityColours,
@@ -32,10 +31,9 @@ import {
 import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import { setImportantSentenceThreshold } from "@/redux/actions/tools/assistantActions";
+import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
-
-// import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 
 export default function AssistantTextClassification({
   text,
@@ -296,9 +294,6 @@ export function GaugeCategoriesList({
     arcsLength,
   );
 
-  // gauage chart explanation
-  // const gaugeExplanation = createGaugeExplanation(keyword, arcsLength, colours);
-
   // categories list
   const output = [];
   if (credibilitySignal === keyword("machine_generated_text_title")) {
@@ -324,17 +319,17 @@ export function GaugeCategoriesList({
     }
   }
 
-  // const DETECTION_EXPLANATION_KEYWORDS_SUB = [
-  //   "gauge_scale_modal_explanation_rating_1_sub",
-  //   "gauge_scale_modal_explanation_rating_2_sub",
-  //   "gauge_scale_modal_explanation_rating_3_sub",
-  // ];
-  // const DETECTION_EXPLANATION_KEYWORDS_MGT = [
-  //   "gauge_scale_modal_explanation_rating_1_mgt",
-  //   "gauge_scale_modal_explanation_rating_2_mgt",
-  //   "gauge_scale_modal_explanation_rating_3_mgt",
-  //   "gauge_scale_modal_explanation_rating_4_mgt",
-  // ];
+  const DETECTION_EXPLANATION_KEYWORDS_SUB = [
+    "gauge_scale_modal_explanation_rating_1_sub",
+    "gauge_scale_modal_explanation_rating_2_sub",
+    "gauge_scale_modal_explanation_rating_3_sub",
+  ];
+  const DETECTION_EXPLANATION_KEYWORDS_MGT = [
+    "gauge_scale_modal_explanation_rating_1_mgt",
+    "gauge_scale_modal_explanation_rating_2_mgt",
+    "gauge_scale_modal_explanation_rating_3_mgt",
+    "gauge_scale_modal_explanation_rating_4_mgt",
+  ];
 
   return (
     <>
@@ -363,7 +358,7 @@ export function GaugeCategoriesList({
         </>
       ) : null}
       {gaugeChart}
-      {/* <Box sx={{ textAlign: "start", mt: 2 }}>
+      <Box sx={{ textAlign: "start", mt: 2 }}>
         <GaugeChartModalExplanation
           keyword={keyword}
           keywordsArr={
@@ -375,7 +370,7 @@ export function GaugeCategoriesList({
           keywordModalTitle={"gauge_scale_modal_explanation_title"}
           colors={colours}
         />
-      </Box> */}
+      </Box>
       {credibilitySignal === keyword("machine_generated_text_title") && (
         <>
           <Divider key={`divider_${fullTextScoreLabel}`} sx={{ my: 2 }} />

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import { useColorScheme } from "@mui/material";
+import Box from "@mui/material/Box";
 import Card from "@mui/material/Card";
 import CardContent from "@mui/material/CardContent";
 import CardHeader from "@mui/material/CardHeader";
@@ -30,6 +31,7 @@ import {
 import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import { setImportantSentenceThreshold } from "@/redux/actions/tools/assistantActions";
+import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
@@ -296,7 +298,7 @@ export function GaugeCategoriesList({
   );
 
   // gauage chart explanation
-  const gaugeExplanation = createGaugeExplanation(keyword, arcsLength, colours);
+  // const gaugeExplanation = createGaugeExplanation(keyword, arcsLength, colours);
 
   // categories list
   const output = [];
@@ -322,6 +324,18 @@ export function GaugeCategoriesList({
       }
     }
   }
+
+  const DETECTION_EXPLANATION_KEYWORDS_SUB = [
+    "gauge_scale_modal_explanation_rating_1_sub",
+    "gauge_scale_modal_explanation_rating_2_sub",
+    "gauge_scale_modal_explanation_rating_3_sub",
+  ];
+  const DETECTION_EXPLANATION_KEYWORDS_MGT = [
+    "gauge_scale_modal_explanation_rating_1_mgt",
+    "gauge_scale_modal_explanation_rating_2_mgt",
+    "gauge_scale_modal_explanation_rating_3_mgt",
+    "gauge_scale_modal_explanation_rating_4_mgt",
+  ];
 
   return (
     <>
@@ -350,7 +364,19 @@ export function GaugeCategoriesList({
         </>
       ) : null}
       {gaugeChart}
-      {gaugeExplanation}
+      <Box sx={{ textAlign: "start", mt: 2 }}>
+        <GaugeChartModalExplanation
+          keyword={keyword}
+          keywordsArr={
+            credibilitySignal === keyword("machine_generated_text_title")
+              ? DETECTION_EXPLANATION_KEYWORDS_MGT
+              : DETECTION_EXPLANATION_KEYWORDS_SUB
+          }
+          keywordLink={"gauge_scale_explanation_link"}
+          keywordModalTitle={"gauge_scale_modal_explanation_title"}
+          colors={colours}
+        />
+      </Box>
       {credibilitySignal === keyword("machine_generated_text_title") && (
         <>
           <Divider key={`divider_${fullTextScoreLabel}`} sx={{ my: 2 }} />

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/AssistantTextClassification.jsx
@@ -20,7 +20,8 @@ import HelpOutlineOutlinedIcon from "@mui/icons-material/HelpOutlineOutlined";
 
 import {
   ThresholdSlider,
-  createGaugeExplanation,
+  // createGaugeExplanation,
+  createGaugeChart,
   getMgtColours,
   getSubjectivityColours,
   rgbToLuminance,
@@ -31,11 +32,10 @@ import {
 import { i18nLoadNamespace } from "@/components/Shared/Languages/i18nLoadNamespace";
 import useMyStyles from "@/components/Shared/MaterialUiStyles/useMyStyles";
 import { setImportantSentenceThreshold } from "@/redux/actions/tools/assistantActions";
-import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
-import { createGaugeChart } from "./assistantUtils";
+// import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 
 export default function AssistantTextClassification({
   text,
@@ -293,7 +293,6 @@ export function GaugeCategoriesList({
     colours,
     keyword,
     gaugeLabels,
-    false,
     arcsLength,
   );
 
@@ -325,17 +324,17 @@ export function GaugeCategoriesList({
     }
   }
 
-  const DETECTION_EXPLANATION_KEYWORDS_SUB = [
-    "gauge_scale_modal_explanation_rating_1_sub",
-    "gauge_scale_modal_explanation_rating_2_sub",
-    "gauge_scale_modal_explanation_rating_3_sub",
-  ];
-  const DETECTION_EXPLANATION_KEYWORDS_MGT = [
-    "gauge_scale_modal_explanation_rating_1_mgt",
-    "gauge_scale_modal_explanation_rating_2_mgt",
-    "gauge_scale_modal_explanation_rating_3_mgt",
-    "gauge_scale_modal_explanation_rating_4_mgt",
-  ];
+  // const DETECTION_EXPLANATION_KEYWORDS_SUB = [
+  //   "gauge_scale_modal_explanation_rating_1_sub",
+  //   "gauge_scale_modal_explanation_rating_2_sub",
+  //   "gauge_scale_modal_explanation_rating_3_sub",
+  // ];
+  // const DETECTION_EXPLANATION_KEYWORDS_MGT = [
+  //   "gauge_scale_modal_explanation_rating_1_mgt",
+  //   "gauge_scale_modal_explanation_rating_2_mgt",
+  //   "gauge_scale_modal_explanation_rating_3_mgt",
+  //   "gauge_scale_modal_explanation_rating_4_mgt",
+  // ];
 
   return (
     <>
@@ -364,7 +363,7 @@ export function GaugeCategoriesList({
         </>
       ) : null}
       {gaugeChart}
-      <Box sx={{ textAlign: "start", mt: 2 }}>
+      {/* <Box sx={{ textAlign: "start", mt: 2 }}>
         <GaugeChartModalExplanation
           keyword={keyword}
           keywordsArr={
@@ -376,7 +375,7 @@ export function GaugeCategoriesList({
           keywordModalTitle={"gauge_scale_modal_explanation_title"}
           colors={colours}
         />
-      </Box>
+      </Box> */}
       {credibilitySignal === keyword("machine_generated_text_title") && (
         <>
           <Divider key={`divider_${fullTextScoreLabel}`} sx={{ my: 2 }} />

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
@@ -7,7 +7,7 @@ import ListItem from "@mui/material/ListItem";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
-// import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
+import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
@@ -295,35 +295,35 @@ export function getPersuasionCategoryTechnique(category) {
   return category.split("__");
 }
 
-// // machine generated text and subjectivity: gauge chart explanation
-// export function createGaugeExplanation(keyword, arcsLength, colours) {
-//   let keywordsArr;
-//   if (arcsLength.length === 3) {
-//     keywordsArr = [
-//       "gauge_scale_modal_explanation_rating_1_sub",
-//       "gauge_scale_modal_explanation_rating_2_sub",
-//       "gauge_scale_modal_explanation_rating_3_sub",
-//     ];
-//   } else if (arcsLength.length === 4) {
-//     keywordsArr = [
-//       "gauge_scale_modal_explanation_rating_1_mgt",
-//       "gauge_scale_modal_explanation_rating_2_mgt",
-//       "gauge_scale_modal_explanation_rating_3_mgt",
-//       "gauge_scale_modal_explanation_rating_4_mgt",
-//     ];
-//   }
-//   return (
-//     <Box sx={{ textAlign: "start", mt: 2 }}>
-//       <GaugeChartModalExplanation
-//         keyword={keyword}
-//         keywordsArr={keywordsArr}
-//         keywordLink={"gauge_scale_explanation_link"}
-//         keywordModalTitle={"gauge_scale_modal_explanation_title"}
-//         colors={colours}
-//       />
-//     </Box>
-//   );
-// }
+// machine generated text and subjectivity: gauge chart explanation
+export function createGaugeExplanation(keyword, arcsLength, colours) {
+  let keywordsArr;
+  if (arcsLength.length === 3) {
+    keywordsArr = [
+      "gauge_scale_modal_explanation_rating_1_sub",
+      "gauge_scale_modal_explanation_rating_2_sub",
+      "gauge_scale_modal_explanation_rating_3_sub",
+    ];
+  } else if (arcsLength.length === 4) {
+    keywordsArr = [
+      "gauge_scale_modal_explanation_rating_1_mgt",
+      "gauge_scale_modal_explanation_rating_2_mgt",
+      "gauge_scale_modal_explanation_rating_3_mgt",
+      "gauge_scale_modal_explanation_rating_4_mgt",
+    ];
+  }
+  return (
+    <Box sx={{ textAlign: "start", mt: 2 }}>
+      <GaugeChartModalExplanation
+        keyword={keyword}
+        keywordsArr={keywordsArr}
+        keywordLink={"gauge_scale_explanation_link"}
+        keywordModalTitle={"gauge_scale_modal_explanation_title"}
+        colors={colours}
+      />
+    </Box>
+  );
+}
 
 /**
  * Creates a GaugeChart required by machine generated text and subjectivity
@@ -333,7 +333,6 @@ export function getPersuasionCategoryTechnique(category) {
  * @param colours
  * @param keyword
  * @param gaugeDetectionText
- * @param explanation
  * @param arcsLength
  * @returns GaugeChart
  */
@@ -344,7 +343,6 @@ export function createGaugeChart(
   colours,
   keyword,
   gaugeDetectionText,
-  explanation,
   arcsLength,
 ) {
   const percentScore = Math.round(Number(overallClassificationScore) * 100.0);
@@ -382,7 +380,7 @@ export function createGaugeChart(
       </Box>
 
       {/* Gauge explanation */}
-      {/* {explanation && createGaugeExplanation(keyword, arcsLength, colours)} */}
+      {createGaugeExplanation(keyword, arcsLength, colours)}
     </>
   );
 }

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
@@ -7,11 +7,8 @@ import ListItem from "@mui/material/ListItem";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
-import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
-
-// import GaugeChartModalExplanation from "../../../Shared/GaugeChartResults/GaugeChartModalExplanation";
 
 /**
  * Interpolate RGB between an arbitrary range
@@ -295,36 +292,6 @@ export function getPersuasionCategoryTechnique(category) {
   return category.split("__");
 }
 
-// machine generated text and subjectivity: gauge chart explanation
-export function createGaugeExplanation(keyword, arcsLength, colours) {
-  let keywordsArr;
-  if (arcsLength.length === 3) {
-    keywordsArr = [
-      "gauge_scale_modal_explanation_rating_1_sub",
-      "gauge_scale_modal_explanation_rating_2_sub",
-      "gauge_scale_modal_explanation_rating_3_sub",
-    ];
-  } else if (arcsLength.length === 4) {
-    keywordsArr = [
-      "gauge_scale_modal_explanation_rating_1_mgt",
-      "gauge_scale_modal_explanation_rating_2_mgt",
-      "gauge_scale_modal_explanation_rating_3_mgt",
-      "gauge_scale_modal_explanation_rating_4_mgt",
-    ];
-  }
-  return (
-    <Box sx={{ textAlign: "start", mt: 2 }}>
-      <GaugeChartModalExplanation
-        keyword={keyword}
-        keywordsArr={keywordsArr}
-        keywordLink={"gauge_scale_explanation_link"}
-        keywordModalTitle={"gauge_scale_modal_explanation_title"}
-        colors={colours}
-      />
-    </Box>
-  );
-}
-
 /**
  * Creates a GaugeChart required by machine generated text and subjectivity
  * @param mgtOverallScoreLabel
@@ -378,9 +345,6 @@ export function createGaugeChart(
           {keyword(gaugeDetectionText[1])}
         </Typography>
       </Box>
-
-      {/* Gauge explanation */}
-      {createGaugeExplanation(keyword, arcsLength, colours)}
     </>
   );
 }

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
@@ -7,11 +7,11 @@ import ListItem from "@mui/material/ListItem";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
+import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
-// import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
-import GaugeChartModalExplanation from "../../../Shared/GaugeChartResults/GaugeChartModalExplanation";
+// import GaugeChartModalExplanation from "../../../Shared/GaugeChartResults/GaugeChartModalExplanation";
 
 /**
  * Interpolate RGB between an arbitrary range

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
@@ -7,9 +7,11 @@ import ListItem from "@mui/material/ListItem";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
-import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
+
+// import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
+import GaugeChartModalExplanation from "../../../Shared/GaugeChartResults/GaugeChartModalExplanation";
 
 /**
  * Interpolate RGB between an arbitrary range

--- a/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
+++ b/src/components/NavItems/Assistant/AssistantScrapeResults/assistantUtils.jsx
@@ -7,7 +7,7 @@ import ListItem from "@mui/material/ListItem";
 import Slider from "@mui/material/Slider";
 import Typography from "@mui/material/Typography";
 
-import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
+// import GaugeChartModalExplanation from "@Shared/GaugeChartResults/GaugeChartModalExplanation";
 import _ from "lodash";
 import { v4 as uuidv4 } from "uuid";
 
@@ -295,35 +295,35 @@ export function getPersuasionCategoryTechnique(category) {
   return category.split("__");
 }
 
-// machine generated text and subjectivity: gauge chart explanation
-export function createGaugeExplanation(keyword, arcsLength, colours) {
-  let keywordsArr;
-  if (arcsLength.length === 3) {
-    keywordsArr = [
-      "gauge_scale_modal_explanation_rating_1_sub",
-      "gauge_scale_modal_explanation_rating_2_sub",
-      "gauge_scale_modal_explanation_rating_3_sub",
-    ];
-  } else if (arcsLength.length === 4) {
-    keywordsArr = [
-      "gauge_scale_modal_explanation_rating_1_mgt",
-      "gauge_scale_modal_explanation_rating_2_mgt",
-      "gauge_scale_modal_explanation_rating_3_mgt",
-      "gauge_scale_modal_explanation_rating_4_mgt",
-    ];
-  }
-  return (
-    <Box sx={{ textAlign: "start", mt: 2 }}>
-      <GaugeChartModalExplanation
-        keyword={keyword}
-        keywordsArr={keywordsArr}
-        keywordLink={"gauge_scale_explanation_link"}
-        keywordModalTitle={"gauge_scale_modal_explanation_title"}
-        colors={colours}
-      />
-    </Box>
-  );
-}
+// // machine generated text and subjectivity: gauge chart explanation
+// export function createGaugeExplanation(keyword, arcsLength, colours) {
+//   let keywordsArr;
+//   if (arcsLength.length === 3) {
+//     keywordsArr = [
+//       "gauge_scale_modal_explanation_rating_1_sub",
+//       "gauge_scale_modal_explanation_rating_2_sub",
+//       "gauge_scale_modal_explanation_rating_3_sub",
+//     ];
+//   } else if (arcsLength.length === 4) {
+//     keywordsArr = [
+//       "gauge_scale_modal_explanation_rating_1_mgt",
+//       "gauge_scale_modal_explanation_rating_2_mgt",
+//       "gauge_scale_modal_explanation_rating_3_mgt",
+//       "gauge_scale_modal_explanation_rating_4_mgt",
+//     ];
+//   }
+//   return (
+//     <Box sx={{ textAlign: "start", mt: 2 }}>
+//       <GaugeChartModalExplanation
+//         keyword={keyword}
+//         keywordsArr={keywordsArr}
+//         keywordLink={"gauge_scale_explanation_link"}
+//         keywordModalTitle={"gauge_scale_modal_explanation_title"}
+//         colors={colours}
+//       />
+//     </Box>
+//   );
+// }
 
 /**
  * Creates a GaugeChart required by machine generated text and subjectivity
@@ -382,7 +382,7 @@ export function createGaugeChart(
       </Box>
 
       {/* Gauge explanation */}
-      {explanation && createGaugeExplanation(keyword, arcsLength, colours)}
+      {/* {explanation && createGaugeExplanation(keyword, arcsLength, colours)} */}
     </>
   );
 }


### PR DESCRIPTION
Finding a fix for the import error on GaugeChartModalExplanation

Tests on github error: https://github.com/AFP-Medialab/verification-plugin/pull/787#discussion_r2372160750

Correct import path as used in Hiya tool: https://github.com/AFP-Medialab/verification-plugin/pull/787#discussion_r2379010795
